### PR TITLE
Decouple publishing from instantiating data transfer

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -3,7 +3,6 @@ package legs
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	dt "github.com/filecoin-project/go-data-transfer"
 	"github.com/ipfs/go-cid"
@@ -74,7 +73,7 @@ func newSubscriber(ctx context.Context, dt *LegTransport, policy PolicyHandler) 
 		return nil, err
 	}
 	// Add refC to track how many subscribers are using the transport.
-	dt.addRefc()
+	dt.AddReference()
 
 	return ls, nil
 }
@@ -229,7 +228,7 @@ func (ls *legSubscriber) OnChange() (chan cid.Cid, context.CancelFunc) {
 }
 
 func (ls *legSubscriber) Close() error {
-	atomic.AddInt32(&ls.transfer.refc, -1)
+	ls.transfer.RemoveReference()
 	ls.cancel()
 	return nil
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,76 @@
+package legs
+
+import (
+	"context"
+	"sync/atomic"
+
+	dt "github.com/filecoin-project/go-data-transfer"
+
+	"github.com/ipld/go-ipld-prime"
+)
+
+// Reference wraps an atomic ref counter
+type Reference interface {
+	AddReference()
+	RemoveReference()
+	RefCount() int32
+}
+
+// NewReference instantiates an atomic ref counter
+func NewReference() Reference {
+	return &reference{}
+}
+
+type reference struct {
+	refc int32
+}
+
+func (r *reference) AddReference() {
+	atomic.AddInt32(&r.refc, 1)
+}
+
+func (r *reference) RemoveReference() {
+	atomic.AddInt32(&r.refc, -1)
+}
+
+func (r *reference) RefCount() int32 {
+	return atomic.LoadInt32(&r.refc)
+}
+
+// ConfigureDataTransferForLegs configures an existing data transfer instance to serve go-legs requests
+// from given linksystem (publisher only)
+func ConfigureDataTransferForLegs(ctx context.Context, dt dt.Manager, lsys ipld.LinkSystem) error {
+	v := &Voucher{}
+	lvr := &VoucherResult{}
+	val := &legsValidator{}
+	lsc := legStorageConfigration{lsys}
+	if err := dt.RegisterVoucherType(v, val); err != nil {
+		return err
+	}
+	if err := dt.RegisterVoucherResultType(lvr); err != nil {
+		return err
+	}
+	if err := dt.RegisterTransportConfigurer(v, lsc.configureTransport); err != nil {
+		return err
+	}
+	return nil
+}
+
+type storeConfigurableTransport interface {
+	UseStore(dt.ChannelID, ipld.LinkSystem) error
+}
+
+type legStorageConfigration struct {
+	linkSystem ipld.LinkSystem
+}
+
+func (lsc legStorageConfigration) configureTransport(chid dt.ChannelID, voucher dt.Voucher, transport dt.Transport) {
+	storeConfigurableTransport, ok := transport.(storeConfigurableTransport)
+	if !ok {
+		return
+	}
+	err := storeConfigurableTransport.UseStore(chid, lsc.linkSystem)
+	if err != nil {
+		log.Errorf("attempting to configure data store: %s", err)
+	}
+}


### PR DESCRIPTION
# Goals

In the reference provider, we need to serve go-legs while also serving retrievals (this will be needed in filecoin integration as well). This means we can't instantiate go-data-transfer inside the LegsTransport. And we don't want legsTransport.Close to shut the whole thing down either.

# Implementation

I'm not sure if this is the right approach -- ideally, what I'd like to do is get rid of LegsTransport altogether -- I'm not sure I understand the value of this abstraction, especially since it's main method is not used.

BUT we have code expecting go-legs to behave the way it does so I chose an initial path that avoids breaking anything. Open to other suggestions.