### PR TITLE
http-transport legs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,10 @@ require (
 	github.com/ipld/go-ipld-prime v0.12.0
 	github.com/libp2p/go-libp2p v0.15.0
 	github.com/libp2p/go-libp2p-core v0.9.0
+	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-pubsub v0.5.4
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
+	github.com/multiformats/go-multiaddr v0.4.0
 	github.com/multiformats/go-multicodec v0.3.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210713220151-be142a5ae1a8
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1

--- a/go.sum
+++ b/go.sum
@@ -598,6 +598,7 @@ github.com/libp2p/go-libp2p-core v0.8.5/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJB
 github.com/libp2p/go-libp2p-core v0.8.6/go.mod h1:dgHr0l0hIKfWpGpqAMbpo19pen9wJfdCGv51mTmdpmM=
 github.com/libp2p/go-libp2p-core v0.9.0 h1:t97Mv0LIBZlP2FXVRNKKVzHJCIjbIWGxYptGId4+htU=
 github.com/libp2p/go-libp2p-core v0.9.0/go.mod h1:ESsbz31oC3C1AvMJoGx26RTuCkNhmkSRCqZ0kQtJ2/8=
+github.com/libp2p/go-libp2p-crypto v0.1.0 h1:k9MFy+o2zGDNGsaoZl0MA3iZ75qXxr9OOoAZF+sD5OQ=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0/go.mod h1:4F/x+aldVHjHDHuX85x1zWoFTGElt8HnoDzwkFZm29g=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
@@ -622,6 +623,7 @@ github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCTh
 github.com/libp2p/go-libp2p-noise v0.1.1/go.mod h1:QDFLdKX7nluB7DEnlVPbz7xlLHdwHFA9HiohJRr3vwM=
 github.com/libp2p/go-libp2p-noise v0.2.2 h1:MRt5XGfYziDXIUy2udtMWfPmzZqUDYoC1FZoKnqPzwk=
 github.com/libp2p/go-libp2p-noise v0.2.2/go.mod h1:IEbYhBBzGyvdLBoxxULL/SGbJARhUeqlO8lVSREYu2Q=
+github.com/libp2p/go-libp2p-peer v0.2.0 h1:EQ8kMjaCUwt/Y5uLgjT8iY2qg0mGUT0N1zUjer50DsY=
 github.com/libp2p/go-libp2p-peer v0.2.0/go.mod h1:RCffaCvUyW2CJmG2gAWVqwePwW7JMgxjsHm7+J5kjWY=
 github.com/libp2p/go-libp2p-peerstore v0.1.0/go.mod h1:2CeHkQsr8svp4fZ+Oi9ykN1HBb6u0MOvdJ7YIsmcwtY=
 github.com/libp2p/go-libp2p-peerstore v0.1.3/go.mod h1:BJ9sHlm59/80oSkpWgr1MyY1ciXAXV397W6h1GH/uKI=

--- a/http/subscribe.go
+++ b/http/subscribe.go
@@ -1,0 +1,164 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"sync"
+
+	"github.com/filecoin-project/go-legs"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	peer "github.com/libp2p/go-libp2p-peer"
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+	"github.com/multiformats/go-multicodec"
+)
+
+// NewHTTPSubscriber creates a legs subcriber that provides subscriptions
+// from publishers identified by
+func NewHTTPSubscriber(ctx context.Context, host *http.Client, publisher multiaddr.Multiaddr, lsys *ipld.LinkSystem, topic string) (legs.LegSubscriber, error) {
+	url, err := toURL(publisher)
+	if err != nil {
+		return nil, err
+	}
+	hs := httpSubscriber{
+		host,
+		cid.Undef,
+		url,
+
+		lsys,
+		sync.Mutex{},
+		make([]chan cid.Cid, 1),
+	}
+	return &hs, nil
+}
+
+// toURL takes a multiaddr of the form:
+// /dnsaddr/thing.com/http/path/to/root
+// /ip/192.168.0.1/http
+// TODO: doesn't support including a signing key definition yet
+func toURL(ma multiaddr.Multiaddr) (string, error) {
+	// host should be either the dns name or the IP
+	_, host, err := manet.DialArgs(ma)
+	if err != nil {
+		return "", err
+	}
+	_, http := multiaddr.SplitFunc(ma, func(c multiaddr.Component) bool {
+		return c.Protocol().Code == multiaddr.P_HTTP
+	})
+	if len(http.Bytes()) == 0 {
+		return "", fmt.Errorf("publisher must be HTTP protocol for this subscriber, was: %s", ma)
+	}
+	_, path := multiaddr.SplitFirst(http)
+	return fmt.Sprintf("https://%s/%s", host, path), nil
+}
+
+type httpSubscriber struct {
+	*http.Client
+	head cid.Cid
+	root string
+
+	lsys   *ipld.LinkSystem
+	submtx sync.Mutex
+	subs   []chan cid.Cid
+}
+
+func (h *httpSubscriber) OnChange() (chan cid.Cid, context.CancelFunc) {
+	ch := make(chan cid.Cid)
+	h.submtx.Lock()
+	defer h.submtx.Unlock()
+	h.subs = append(h.subs, ch)
+	cncl := func() {
+		h.submtx.Lock()
+		defer h.submtx.Unlock()
+		for i, ca := range h.subs {
+			if ca == ch {
+				h.subs[i] = h.subs[len(h.subs)-1]
+				h.subs[len(h.subs)-1] = nil
+				h.subs = h.subs[:len(h.subs)-1]
+				close(ch)
+				break
+			}
+		}
+	}
+	return ch, cncl
+}
+
+// Not supported, since gossip-sub is not supported by this handler.
+// `Sync` must be called explicitly to trigger a fetch instead.
+func (h *httpSubscriber) SetPolicyHandler(p legs.PolicyHandler) error {
+	return nil
+}
+
+func (h *httpSubscriber) SetLatestSync(c cid.Cid) error {
+	h.head = c
+	return nil
+}
+
+func (h *httpSubscriber) Sync(ctx context.Context, p peer.ID, c cid.Cid) (chan cid.Cid, context.CancelFunc, error) {
+	return nil, nil, nil
+}
+
+func (h *httpSubscriber) Close() error {
+	return nil
+}
+
+func (h *httpSubscriber) fetch(url string, cb func(io.Reader) error) error {
+	resp, err := h.Client.Get(path.Join(h.root, url))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("non success http code at %s/%s: %d", h.root, url, resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	return cb(resp.Body)
+}
+
+func (h *httpSubscriber) fetchHead() (cid.Cid, error) {
+	var cidStr string
+	if err := h.fetch("head", func(msg io.Reader) error {
+		return json.NewDecoder(msg).Decode(&cidStr)
+	}); err != nil {
+		return cid.Undef, err
+	}
+
+	return cid.Decode(cidStr)
+}
+
+// fetch an item into the datastore at c if not locally avilable.
+func (h *httpSubscriber) fetchDag(c cid.Cid) error {
+	n, err := h.lsys.Load(ipld.LinkContext{}, cidlink.Link{Cid: c}, basicnode.Prototype.Any)
+	// node is already present.
+	if n != nil && err == nil {
+		return nil
+	}
+
+	return h.fetch(c.String(), func(data io.Reader) error {
+		buf := bytes.NewBuffer(nil)
+		if _, err := io.Copy(buf, data); err != nil {
+			return err
+		}
+		b := basicnode.NewBytes(buf.Bytes())
+		// we're storing just as 'raw', but will later interpret with c's codec
+		pref := c.Prefix()
+		pref.Codec = uint64(multicodec.Raw)
+		ec, err := h.lsys.Store(ipld.LinkContext{}, cidlink.LinkPrototype{Prefix: pref}, b)
+		if err != nil {
+			return err
+		}
+
+		if ec.(cidlink.Link).Cid.Hash().B58String() != c.Hash().B58String() {
+			return fmt.Errorf("content did not match expected hash: %s vs %s", ec, c)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Conceptually, provide the same publisher and subscriber interface as legs, but with subscriber pulling from static files that the publisher makes available in an HTTP directory.

* does not handle alerts of updated head in-band. a second notification protocol would be needed, as this will either poll, or use manual calls to`Sync` to fetch.