### PR TITLE
Fix race condition in sync tests

### DIFF
--- a/subscribe.go
+++ b/subscribe.go
@@ -32,6 +32,7 @@ type legSubscriber struct {
 	policy          PolicyHandler
 	defaultSelector ipld.Node
 
+	// syncmtx synchronizes read/write for latestSync and syncing
 	syncmtx    sync.Mutex
 	latestSync ipld.Link
 	syncing    cid.Cid
@@ -304,4 +305,12 @@ func (ls *legSubscriber) onSyncEvent(c cid.Cid, out chan cid.Cid, ulOnce *sync.O
 			}
 		}
 	}
+}
+
+// getLatestSync gets the latest synced link.
+// This function is safe to call from multiple goroutines and exposed for testing purposes only.
+func (ls *legSubscriber) getLatestSync() ipld.Link {
+	ls.syncmtx.Lock()
+	defer ls.syncmtx.Unlock()
+	return ls.latestSync
 }


### PR DESCRIPTION
Fix a race condition where gorutines compete to read the value of latest
synced link by introducing a read-lock.

Update test timeouts slightly to accommodate CI run tests.

Refactor tests to reduce duplicate code.

Relates to:
 - https://github.com/filecoin-project/go-legs/pull/29