### PR TITLE
Add message originator addresses to peerstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,9 @@ require (
 	github.com/libp2p/go-libp2p-core v0.9.0
 	github.com/libp2p/go-libp2p-pubsub v0.5.4
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
-	github.com/multiformats/go-multiaddr v0.4.0
+	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/multiformats/go-multicodec v0.3.0
+	github.com/multiformats/go-varint v0.0.6
 	github.com/whyrusleeping/cbor-gen v0.0.0-20210713220151-be142a5ae1a8
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -843,8 +843,9 @@ github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u
 github.com/multiformats/go-multiaddr v0.3.0/go.mod h1:dF9kph9wfJ+3VLAaeBqo9Of8x4fJxp6ggJGteB8HQTI=
 github.com/multiformats/go-multiaddr v0.3.1/go.mod h1:uPbspcUPd5AfaP6ql3ujFY+QWzmBD8uLLL4bXW0XfGc=
 github.com/multiformats/go-multiaddr v0.3.3/go.mod h1:lCKNGP1EQ1eZ35Za2wlqnabm9xQkib3fyB+nZXHLag0=
-github.com/multiformats/go-multiaddr v0.4.0 h1:hL/K4ZJhJ5PTw3nwylq9lGU5yArzcAroZmex1ghSEkQ=
 github.com/multiformats/go-multiaddr v0.4.0/go.mod h1:YcpyLH8ZPudLxQlemYBPhSm0/oCXAT8Z4mzFpyoPyRc=
+github.com/multiformats/go-multiaddr v0.4.1 h1:Pq37uLx3hsyNlTDir7FZyU8+cFCTqd5y1KiM2IzOutI=
+github.com/multiformats/go-multiaddr v0.4.1/go.mod h1:3afI9HfVW8csiF8UZqtpYRiDyew8pRX7qLIGHu9FLuM=
 github.com/multiformats/go-multiaddr-dns v0.0.1/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.0.2/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
 github.com/multiformats/go-multiaddr-dns v0.2.0/go.mod h1:TJ5pr5bBO7Y1B18djPuRsVkduhQH2YqYSbxWJzYGdK0=

--- a/message.go
+++ b/message.go
@@ -1,0 +1,63 @@
+package legs
+
+import (
+	"bytes"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-varint"
+)
+
+func encodeMessage(c cid.Cid, addrs []multiaddr.Multiaddr) []byte {
+	// Get size
+	var size, maxVarintLen int
+	for i := range addrs {
+		addrBytes := addrs[i].Bytes()
+		varintLen := varint.UvarintSize(uint64(len(addrBytes)))
+		if varintLen > maxVarintLen {
+			maxVarintLen = varintLen
+		}
+		size += len(addrBytes) + varintLen
+	}
+
+	vibuf := make([]byte, maxVarintLen)
+	var b bytes.Buffer
+	b.Grow(c.ByteLen() + size)
+	// CID already contains encoded length, so no need to add length to data.
+	c.WriteBytes(&b)
+
+	for i := range addrs {
+		addrBytes := addrs[i].Bytes()
+		n := varint.PutUvarint(vibuf, uint64(len(addrBytes)))
+		b.Write(vibuf[:n])
+		b.Write(addrBytes)
+	}
+
+	return b.Bytes()
+}
+
+func decodeMessage(data []byte) (cid.Cid, []multiaddr.Multiaddr, error) {
+	n, c, err := cid.CidFromBytes(data)
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+	data = data[n:]
+
+	var addrs []multiaddr.Multiaddr
+	for len(data) != 0 {
+		val, n, err := varint.FromUvarint(data)
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+		data = data[n:]
+
+		addr, err := multiaddr.NewMultiaddrBytes(data[:val])
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+		data = data[val:]
+		addrs = append(addrs, addr)
+	}
+
+	return c, addrs, nil
+}

--- a/message.go
+++ b/message.go
@@ -8,11 +8,16 @@ import (
 	"github.com/multiformats/go-varint"
 )
 
-func encodeMessage(c cid.Cid, addrs []multiaddr.Multiaddr) []byte {
+type message struct {
+	cid   cid.Cid
+	addrs []multiaddr.Multiaddr
+}
+
+func encodeMessage(m message) []byte {
 	// Get size
 	var size, maxVarintLen int
-	for i := range addrs {
-		addrBytes := addrs[i].Bytes()
+	for _, addr := range m.addrs {
+		addrBytes := addr.Bytes()
 		varintLen := varint.UvarintSize(uint64(len(addrBytes)))
 		if varintLen > maxVarintLen {
 			maxVarintLen = varintLen
@@ -22,12 +27,12 @@ func encodeMessage(c cid.Cid, addrs []multiaddr.Multiaddr) []byte {
 
 	vibuf := make([]byte, maxVarintLen)
 	var b bytes.Buffer
-	b.Grow(c.ByteLen() + size)
+	b.Grow(m.cid.ByteLen() + size)
 	// CID already contains encoded length, so no need to add length to data.
-	c.WriteBytes(&b)
+	m.cid.WriteBytes(&b)
 
-	for i := range addrs {
-		addrBytes := addrs[i].Bytes()
+	for _, addr := range m.addrs {
+		addrBytes := addr.Bytes()
 		n := varint.PutUvarint(vibuf, uint64(len(addrBytes)))
 		b.Write(vibuf[:n])
 		b.Write(addrBytes)
@@ -36,10 +41,10 @@ func encodeMessage(c cid.Cid, addrs []multiaddr.Multiaddr) []byte {
 	return b.Bytes()
 }
 
-func decodeMessage(data []byte) (cid.Cid, []multiaddr.Multiaddr, error) {
+func decodeMessage(data []byte) (message, error) {
 	n, c, err := cid.CidFromBytes(data)
 	if err != nil {
-		return cid.Undef, nil, err
+		return message{}, err
 	}
 	data = data[n:]
 
@@ -47,17 +52,20 @@ func decodeMessage(data []byte) (cid.Cid, []multiaddr.Multiaddr, error) {
 	for len(data) != 0 {
 		val, n, err := varint.FromUvarint(data)
 		if err != nil {
-			return cid.Undef, nil, err
+			return message{}, err
 		}
 		data = data[n:]
 
 		addr, err := multiaddr.NewMultiaddrBytes(data[:val])
 		if err != nil {
-			return cid.Undef, nil, err
+			return message{}, err
 		}
 		data = data[val:]
 		addrs = append(addrs, addr)
 	}
 
-	return c, addrs, nil
+	return message{
+		cid:   c,
+		addrs: addrs,
+	}, nil
 }

--- a/message_test.go
+++ b/message_test.go
@@ -22,25 +22,29 @@ func TestEncodeDecodeMessage(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	maddrs := []multiaddr.Multiaddr{maddrA, maddrB}
 
-	data := encodeMessage(c, maddrs)
+	msg1 := message{
+		cid:   c,
+		addrs: []multiaddr.Multiaddr{maddrA, maddrB},
+	}
 
-	c2, maddrs2, err := decodeMessage(data)
+	data := encodeMessage(msg1)
+
+	msg2, err := decodeMessage(data)
 	if err != nil {
 		t.Fatalf("Failed to decode message: %s", err)
 	}
 
-	if !c2.Equals(c) {
+	if !msg2.cid.Equals(msg1.cid) {
 		t.Fatal("Decoded cid is not equal to original")
 	}
 
-	if len(maddrs2) != len(maddrs) {
-		t.Fatalf("Wrong number of addresses, expected 2 got %d", len(maddrs2))
+	if len(msg2.addrs) != len(msg1.addrs) {
+		t.Fatalf("Wrong number of addresses, expected 2 got %d", len(msg2.addrs))
 	}
-	for i := range maddrs2 {
-		if !maddrs2[i].Equal(maddrs[i]) {
-			t.Fatalf("Decoded multiaddr %d %q is not equal to original %q", i, maddrs2[i], maddrs[i])
+	for i := range msg2.addrs {
+		if !msg2.addrs[i].Equal(msg1.addrs[i]) {
+			t.Fatalf("Decoded multiaddr %d %q is not equal to original %q", i, msg2.addrs[i], msg1.addrs[i])
 		}
 	}
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,46 @@
+package legs
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func TestEncodeDecodeMessage(t *testing.T) {
+	cidStr := "QmPNHBy5h7f19yJDt7ip9TvmMRbqmYsa6aetkrsc1ghjLB"
+	c, err := cid.Decode(cidStr)
+	if err != nil {
+		panic(err)
+	}
+
+	maddrA, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/9999")
+	if err != nil {
+		panic(err)
+	}
+	maddrB, err := multiaddr.NewMultiaddr("/ip4/192.168.0.1/tcp/2701")
+	if err != nil {
+		panic(err)
+	}
+	maddrs := []multiaddr.Multiaddr{maddrA, maddrB}
+
+	data := encodeMessage(c, maddrs)
+
+	c2, maddrs2, err := decodeMessage(data)
+	if err != nil {
+		t.Fatalf("Failed to decode message: %s", err)
+	}
+
+	if !c2.Equals(c) {
+		t.Fatal("Decoded cid is not equal to original")
+	}
+
+	if len(maddrs2) != len(maddrs) {
+		t.Fatalf("Wrong number of addresses, expected 2 got %d", len(maddrs2))
+	}
+	for i := range maddrs2 {
+		if !maddrs2[i].Equal(maddrs[i]) {
+			t.Fatalf("Decoded multiaddr %d %q is not equal to original %q", i, maddrs2[i], maddrs[i])
+		}
+	}
+}

--- a/multisubscribe.go
+++ b/multisubscribe.go
@@ -38,6 +38,7 @@ type legMultiSubscriber struct {
 	gs     graphsync.GraphExchange
 	topic  *pubsub.Topic
 	refc   int32
+	host   host.Host
 
 	// dss captures the default selector sequence passed to ExploreRecursiveWithStopNode
 	dss ipld.Node
@@ -71,13 +72,13 @@ func NewMultiSubscriber(ctx context.Context, host host.Host, ds datastore.Batchi
 		t:      dt,
 		gs:     gs,
 		topic:  t,
+		host:   host,
 		dss:    dss,
 	}, nil
 }
 
 func (lt *legMultiSubscriber) NewSubscriber(policy PolicyHandler) (LegSubscriber, error) {
-
-	l, err := newSubscriber(lt.ctx, lt.t, lt.topic, lt.onCloseSubscriber, policy, lt.dss)
+	l, err := newSubscriber(lt.ctx, lt.t, lt.topic, lt.onCloseSubscriber, lt.host, policy, lt.dss)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (lt *legMultiSubscriber) NewSubscriber(policy PolicyHandler) (LegSubscriber
 }
 
 func (lt *legMultiSubscriber) NewSubscriberPartiallySynced(policy PolicyHandler, latestSync cid.Cid) (LegSubscriber, error) {
-	l, err := newSubscriber(lt.ctx, lt.t, lt.topic, lt.onCloseSubscriber, policy, lt.dss)
+	l, err := newSubscriber(lt.ctx, lt.t, lt.topic, lt.onCloseSubscriber, lt.host, policy, lt.dss)
 	if err != nil {
 		return nil, err
 	}

--- a/publish.go
+++ b/publish.go
@@ -50,8 +50,11 @@ func NewPublisherFromExisting(ctx context.Context,
 
 func (lp *legPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
 	log.Debugf("Published CID and addresses in pubsub channel: %s", c)
-	data := encodeMessage(c, lp.host.Addrs())
-	return lp.topic.Publish(ctx, data)
+	msg := message{
+		cid:   c,
+		addrs: lp.host.Addrs(),
+	}
+	return lp.topic.Publish(ctx, encodeMessage(msg))
 }
 
 func (lp *legPublisher) Close() error {

--- a/publish.go
+++ b/publish.go
@@ -14,6 +14,7 @@ import (
 type legPublisher struct {
 	topic   *pubsub.Topic
 	onClose func() error
+	host    host.Host
 }
 
 // NewPublisher creates a new legs publisher
@@ -26,7 +27,7 @@ func NewPublisher(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return &legPublisher{ss.t, ss.onClose}, nil
+	return &legPublisher{ss.t, ss.onClose, host}, nil
 }
 
 // NewPublisherFromExisting instantiates go-legs publishing on an existing
@@ -44,12 +45,13 @@ func NewPublisherFromExisting(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	return &legPublisher{t, t.Close}, nil
+	return &legPublisher{t, t.Close, host}, nil
 }
 
 func (lp *legPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
-	log.Debugf("Published CID in pubsub channel: %s", c)
-	return lp.topic.Publish(ctx, c.Bytes())
+	log.Debugf("Published CID and addresses in pubsub channel: %s", c)
+	data := encodeMessage(c, lp.host.Addrs())
+	return lp.topic.Publish(ctx, data)
 }
 
 func (lp *legPublisher) Close() error {


### PR DESCRIPTION
Put the message originator's addresses into the pubsub message.  When this message is received by go-legs, the addresses are added to the peerstore.  This allows datatransfer to make a connection back to the provider to get advertisements and content.  This is necessary when the provider and indexer are not directly connected, but are connected through intermediate nodes.