### PR TITLE
Fix race conditions

### DIFF
--- a/legs_test.go
+++ b/legs_test.go
@@ -41,14 +41,15 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstLnkS := test.MkLinkSystem(dstStore)
 	ls, err := legs.NewSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
+		t.Fatal(err)
+	}
+
 	return srcHost, dstHost, lp, ls
 }
 
@@ -129,13 +130,13 @@ func TestRoundTripExistingDataTransfer(t *testing.T) {
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstLnkS := test.MkLinkSystem(dstStore)
 	ls, err := legs.NewSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 

--- a/message.go
+++ b/message.go
@@ -49,7 +49,7 @@ func decodeMessage(data []byte) (message, error) {
 	data = data[n:]
 
 	// Read multiaddrs if there is any more data in message data.  This allows
-	// backward-compatability with publishers that do not supply addres data.
+	// backward-compatability with publishers that do not supply address data.
 	var addrs []multiaddr.Multiaddr
 	for len(data) != 0 {
 		val, n, err := varint.FromUvarint(data)

--- a/message.go
+++ b/message.go
@@ -48,6 +48,8 @@ func decodeMessage(data []byte) (message, error) {
 	}
 	data = data[n:]
 
+	// Read multiaddrs if there is any more data in message data.  This allows
+	// backward-compatability with publishers that do not supply addres data.
 	var addrs []multiaddr.Multiaddr
 	for len(data) != 0 {
 		val, n, err := varint.FromUvarint(data)

--- a/multisubscribe_test.go
+++ b/multisubscribe_test.go
@@ -13,7 +13,7 @@ import (
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 )
 
-func TestMultiSusbscribeRoundTrip(t *testing.T) {
+func TestMultiSubscribeRoundTrip(t *testing.T) {
 	// Init legs publisher and subscriber
 	srcStore1 := dssync.MutexWrap(datastore.NewMapDatastore())
 	srcHost1 := mkTestHost()
@@ -38,15 +38,15 @@ func TestMultiSusbscribeRoundTrip(t *testing.T) {
 	dstHost.Peerstore().AddAddrs(srcHost1.ID(), srcHost1.Addrs(), time.Hour)
 	srcHost2.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost2.ID(), srcHost2.Addrs(), time.Hour)
+	dstLnkS := test.MkLinkSystem(dstStore)
+	ms, err := legs.NewMultiSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := srcHost1.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 	if err := srcHost2.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
-	dstLnkS := test.MkLinkSystem(dstStore)
-	ms, err := legs.NewMultiSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
-	if err != nil {
 		t.Fatal(err)
 	}
 	ls1, err := ms.NewSubscriber(legs.FilterPeerPolicy(srcHost1.ID()))

--- a/p2p/protocol/head/head.go
+++ b/p2p/protocol/head/head.go
@@ -18,6 +18,20 @@ import (
 
 const closeTimeout = 30 * time.Second
 
+type Publisher struct {
+	rl     sync.RWMutex
+	root   cid.Cid
+	server *http.Server
+}
+
+func NewPublisher() *Publisher {
+	p := &Publisher{
+		server: &http.Server{},
+	}
+	p.server.Handler = http.Handler(p)
+	return p
+}
+
 func deriveProtocolID(topic string) protocol.ID {
 	return protocol.ID("/legs/head/" + topic + "/0.0.1")
 }
@@ -28,7 +42,6 @@ func (p *Publisher) Serve(host host.Host, topic string) error {
 		return err
 	}
 
-	p.server = &http.Server{Handler: http.Handler(p)}
 	return p.server.Serve(l)
 }
 
@@ -59,12 +72,6 @@ func QueryRootCid(ctx context.Context, host host.Host, topic string, peer peer.I
 	}
 
 	return cid.Decode(string(cidStr))
-}
-
-type Publisher struct {
-	rl     sync.RWMutex
-	root   cid.Cid
-	server *http.Server
 }
 
 func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/p2p/protocol/head/head_test.go
+++ b/p2p/protocol/head/head_test.go
@@ -32,7 +32,7 @@ func TestFetchLatestHead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := &head.Publisher{}
+	p := head.NewPublisher()
 	go p.Serve(publisher, "test")
 	defer p.Close()
 

--- a/publish.go
+++ b/publish.go
@@ -31,7 +31,7 @@ func NewPublisher(ctx context.Context,
 		return nil, err
 	}
 
-	headPublisher := &head.Publisher{}
+	headPublisher := head.NewPublisher()
 	go func() {
 		err := headPublisher.Serve(host, topic)
 		if err != http.ErrServerClosed {
@@ -58,7 +58,7 @@ func NewPublisherFromExisting(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	headPublisher := &head.Publisher{}
+	headPublisher := head.NewPublisher()
 	go func() {
 		err := headPublisher.Serve(host, topic)
 		if err != http.ErrServerClosed {

--- a/sync_test.go
+++ b/sync_test.go
@@ -140,12 +140,12 @@ func TestLatestSyncSuccess(t *testing.T) {
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstLnkS := mkLinkSystem(dstStore)
 	ls, err := NewSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -175,13 +175,13 @@ func TestSyncFn(t *testing.T) {
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstLnkS := mkLinkSystem(dstStore)
 
 	ls, err := NewSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -273,12 +273,12 @@ func TestPartialSync(t *testing.T) {
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstLnkS := mkLinkSystem(dstStore)
 	ls, err := NewSubscriberPartiallySynced(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", chainLnks[3].(cidlink.Link).Cid, nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -326,12 +326,12 @@ func TestStepByStepSync(t *testing.T) {
 	dstHost := mkTestHost()
 	srcHost.Peerstore().AddAddrs(dstHost.ID(), dstHost.Addrs(), time.Hour)
 	dstHost.Peerstore().AddAddrs(srcHost.ID(), srcHost.Addrs(), time.Hour)
-	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
-		t.Fatal(err)
-	}
 	dstLnkS := mkLinkSystem(dstStore)
 	ls, err := NewSubscriber(context.Background(), dstHost, dstStore, dstLnkS, "legs/testtopic", nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srcHost.Connect(context.Background(), dstHost.Peerstore().PeerInfo(dstHost.ID())); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
- Fix one race condition when starting the `head.Publisher` server.
- Fix multiple race conditions in tests where connections need to be created after gossip pubsub is created. This is so that connecting hosts can see that the destination host has pubsub, and will publish messages.

Note: The sleep to wait for the gossip mesh to establish is still needed, but the above fixes a race that when hit would always fail regardless of the gossip mesh wait.