### PR TITLE
Add logging across subscribers and publishers

### DIFF
--- a/http/publish.go
+++ b/http/publish.go
@@ -44,7 +44,7 @@ func (h *httpPublisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		out, err := json.Marshal(h.root.String())
 		if err != nil {
 			w.WriteHeader(500)
-			log.Infow("failed to serve root", "err", err)
+			log.Errorw("Failed to serve root", "err", err)
 		} else {
 			_, _ = w.Write(out)
 		}
@@ -66,7 +66,7 @@ func (h *httpPublisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("unable to load data for cid"))
-		log.Infow("failed to load requested block", "err", err)
+		log.Errorw("Failed to load requested block", "err", err)
 		return
 	}
 	// marshal to json and serve.

--- a/interface.go
+++ b/interface.go
@@ -50,10 +50,11 @@ type PolicyHandler func(*pubsub.Message) (bool, error)
 // if the update is generated from a specific peer.
 func FilterPeerPolicy(p peer.ID) PolicyHandler {
 	return func(msg *pubsub.Message) (bool, error) {
-		src, err := peer.IDFromBytes(msg.From)
-		if err != nil {
-			return false, err
+		from := msg.GetFrom()
+		allow := from == p
+		if !allow {
+			log.Debugf("Filtered pubsub message from %s", from)
 		}
-		return src == p, nil
+		return allow, nil
 	}
 }

--- a/message.go
+++ b/message.go
@@ -54,12 +54,14 @@ func decodeMessage(data []byte) (message, error) {
 	for len(data) != 0 {
 		val, n, err := varint.FromUvarint(data)
 		if err != nil {
+			log.Errorf("Failed to decode message: cannot read number of multiadds: %s", err)
 			return message{}, err
 		}
 		data = data[n:]
 
 		addr, err := multiaddr.NewMultiaddrBytes(data[:val])
 		if err != nil {
+			log.Errorf("Failed to decode message: cannot decode multiadds: %s", err)
 			return message{}, err
 		}
 		data = data[val:]

--- a/selector.go
+++ b/selector.go
@@ -20,6 +20,7 @@ func ExploreRecursiveWithStop(limit selector.RecursionLimit, sequence selectorbu
 // scratch with every update.
 func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.Node, stopLnk ipld.Link) ipld.Node {
 	if sequence == nil {
+		log.Debug("No selector sequence specified; using default explore all with recursive edge.")
 		np := basicnode.Prototype__Any{}
 		ssb := selectorbuilder.NewSelectorSpecBuilder(np)
 		sequence = ssb.ExploreAll(ssb.ExploreRecursiveEdge()).Node()

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,92 @@
+package legs
+
+import (
+	log2 "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/protocol"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+var _ pubsub.RawTracer = (*loggingTracer)(nil)
+
+// loggingTracer is a pubsub.RawTracer that logs the internal operations of the pubsub subsystem
+// for debugging purposes with debug log level.
+type loggingTracer struct {
+	log *log2.ZapEventLogger
+}
+
+func (l *loggingTracer) AddPeer(p peer.ID, proto protocol.ID) {
+	l.log.Debugf("Peer added with ID %s and protocol %s", p, proto)
+}
+
+func (l *loggingTracer) RemovePeer(p peer.ID) {
+	l.log.Debugf("Peer removed with ID %s", p)
+}
+
+func (l *loggingTracer) Join(topic string) {
+	l.log.Debugf("Joined topic %s", topic)
+}
+
+func (l *loggingTracer) Leave(topic string) {
+	l.log.Debugf("Left topic %s", topic)
+}
+
+func (l *loggingTracer) Graft(p peer.ID, topic string) {
+	l.log.Debugf("Grafted peer with ID %s to topic %s", p, topic)
+}
+
+func (l *loggingTracer) Prune(p peer.ID, topic string) {
+	l.log.Debugf("Pruned peer with ID %s from topic %s", p, topic)
+}
+
+func (l *loggingTracer) ValidateMessage(msg *pubsub.Message) {
+	l.log.Debugf("Validating message from peer ID %s on topic %s with size %d bytes",
+		msg.GetFrom(),
+		msg.GetTopic(),
+		msg.Size())
+}
+
+func (l *loggingTracer) DeliverMessage(msg *pubsub.Message) {
+	l.log.Debugf("Delivered message from peer ID %s on topic %s with size %d bytes",
+		msg.GetFrom(),
+		msg.GetTopic(),
+		msg.Size())
+}
+
+func (l *loggingTracer) RejectMessage(msg *pubsub.Message, reason string) {
+	l.log.Debugf("Rejected message from peer ID %s on topic %s with size %d bytes: %s",
+		msg.GetFrom(),
+		msg.GetTopic(),
+		msg.Size(),
+		reason)
+}
+
+func (l *loggingTracer) DuplicateMessage(msg *pubsub.Message) {
+	l.log.Debugf("Dropped duplicate message from peer ID %s on topic %s with size %d bytes",
+		msg.GetFrom(),
+		msg.GetTopic(),
+		msg.Size())
+}
+
+func (l *loggingTracer) ThrottlePeer(p peer.ID) {
+	l.log.Debugf("Throttled peer ID %s", p)
+}
+
+func (l *loggingTracer) RecvRPC(rpc *pubsub.RPC) {
+	l.log.Debugf("Received RPC with size %d bytes", rpc.Size())
+}
+
+func (l *loggingTracer) SendRPC(rpc *pubsub.RPC, p peer.ID) {
+	l.log.Debugf("Sent RPC with size %d bytes to peer ID %s", rpc.Size(), p)
+}
+
+func (l *loggingTracer) DropRPC(rpc *pubsub.RPC, p peer.ID) {
+	l.log.Debugf("Dropped RPC with size %d bytes to peer ID %s", rpc.Size(), p)
+}
+
+func (l *loggingTracer) UndeliverableMessage(msg *pubsub.Message) {
+	l.log.Debugf("Undeliverable message from peer ID %s on topic %s with size %d bytes",
+		msg.GetFrom(),
+		msg.GetTopic(),
+		msg.Size())
+}

--- a/utils.go
+++ b/utils.go
@@ -14,12 +14,11 @@ import (
 	"github.com/ipfs/go-graphsync"
 	gsimpl "github.com/ipfs/go-graphsync/impl"
 	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/minio/blake2b-simd"
-
-	"github.com/ipld/go-ipld-prime"
 )
 
 // configureDataTransferForLegs configures an existing data transfer instance to serve go-legs requests
@@ -30,12 +29,15 @@ func configureDataTransferForLegs(ctx context.Context, dt dt.Manager, lsys ipld.
 	val := &legsValidator{}
 	lsc := legStorageConfigration{lsys}
 	if err := dt.RegisterVoucherType(v, val); err != nil {
+		log.Errorf("Failed to register legs voucher validator type: %s", err)
 		return err
 	}
 	if err := dt.RegisterVoucherResultType(lvr); err != nil {
+		log.Errorf("Failed to register legs voucher result type: %s", err)
 		return err
 	}
 	if err := dt.RegisterTransportConfigurer(v, lsc.configureTransport); err != nil {
+		log.Errorf("Failed to register datatrasfer TransportConfigurer: %s", err)
 		return err
 	}
 	return nil
@@ -69,12 +71,21 @@ func makePubsub(ctx context.Context, h host.Host, topic string) (*pubsub.Topic, 
 		}),
 		pubsub.WithFloodPublish(true),
 		pubsub.WithDirectConnectTicks(directConnectTicks),
+		pubsub.WithRawTracer(&loggingTracer{log}),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("constructing pubsub: %d", err)
+		log.Errorf("Failed instantiate pubsub for topic %s with peer ID %s: %s", topic, h.ID(), err)
+		return nil, fmt.Errorf("failed to instantiate pubsub: %w", err)
 	}
 
-	return p.Join(topic)
+	log.Infof("Instantiated pubsub with peer ID %s", h.ID())
+	t, err := p.Join(topic)
+	if err != nil {
+		log.Errorf("Failed to joing topic %s: %s", topic, err)
+		return nil, err
+	}
+	log.Infof("Joined pubsub topic %s", topic)
+	return t, nil
 }
 
 func makeDataTransfer(ctx context.Context, host host.Host, ds datastore.Batching, lsys ipld.LinkSystem) (dt.Manager, graphsync.GraphExchange, string, error) {
@@ -92,10 +103,13 @@ func makeDataTransfer(ctx context.Context, host host.Host, ds datastore.Batching
 	// this may be removed.
 	tmpDir, err := ioutil.TempDir("", "go-legs")
 	if err != nil {
+		log.Errorf("Failed to create temp dir for datatransfer: %s", err)
 		return nil, nil, "", err
 	}
+	log.Debugf("Created datatransfer temp dir at path: %s", tmpDir)
 	dt, err := datatransfer.NewDataTransfer(ds, tmpDir, dtNet, tp)
 	if err != nil {
+		log.Errorf("Failed to instantiate datatransfer: %s", err)
 		return nil, nil, "", err
 	}
 
@@ -103,12 +117,15 @@ func makeDataTransfer(ctx context.Context, host host.Host, ds datastore.Batching
 	lvr := &VoucherResult{}
 	val := &legsValidator{}
 	if err := dt.RegisterVoucherType(v, val); err != nil {
+		log.Errorf("Failed to register legs validator voucher type: %s", err)
 		return nil, nil, "", err
 	}
 	if err := dt.RegisterVoucherResultType(lvr); err != nil {
+		log.Errorf("Failed to register legs voucher result: %s", err)
 		return nil, nil, "", err
 	}
 	if err := dt.Start(ctx); err != nil {
+		log.Errorf("Failed to start datatransfer: %s", err)
 		return nil, nil, "", err
 	}
 
@@ -142,14 +159,20 @@ func newSimpleSetup(ctx context.Context,
 }
 
 func (ss *simpleSetup) onClose() error {
+	log.Debug("Closing legs simple setup")
 	err := ss.dt.Stop(ss.ctx)
 	err2 := os.RemoveAll(ss.tmpDir)
 	err3 := ss.t.Close()
 	if err != nil {
+		log.Errorf("Failed to stop datatransfer: %s", err)
 		return err
 	}
 	if err2 != nil {
+		log.Errorf("Failed to remove datatransfer temp dir: %s", err2)
 		return err2
+	}
+	if err3 != nil {
+		log.Errorf("Failed to close pubsub topic: %s", err3)
 	}
 	return err3
 }


### PR DESCRIPTION
Add logging for all versions of subscribers and publishers.

Implement a dedicated logger to trace raw publsub messages into logs as
debug level.