### PR TITLE
It is an error to UpdateRoot with an undef cid

### DIFF
--- a/broker_sync_test.go
+++ b/broker_sync_test.go
@@ -328,9 +328,14 @@ func TestBrokerLatestSyncFailure(t *testing.T) {
 }
 
 func newBrokerUpdateTest(t *testing.T, lp LegPublisher, lb *Broker, dstStore datastore.Batching, watcher <-chan SyncFinished, peerID peer.ID, lnk ipld.Link, withFailure bool, expectedSync cid.Cid) {
-	err := lp.UpdateRoot(context.Background(), lnk.(cidlink.Link).Cid)
-	if err != nil {
-		t.Fatal(err)
+	var err error
+
+	c := lnk.(cidlink.Link).Cid
+	if c != cid.Undef {
+		err := lp.UpdateRoot(context.Background(), c)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// If failure. then latestSync should not be updated.
@@ -352,8 +357,8 @@ func newBrokerUpdateTest(t *testing.T, lp LegPublisher, lb *Broker, dstStore dat
 			if !open {
 				return
 			}
-			if !downstream.Cid.Equals(lnk.(cidlink.Link).Cid) {
-				t.Fatalf("sync'd cid unexpected %s vs %s", downstream.Cid, lnk)
+			if !downstream.Cid.Equals(c) {
+				t.Fatalf("sync'd cid unexpected %s vs %s", downstream.Cid, c)
 			}
 			if _, err = dstStore.Get(datastore.NewKey(downstream.Cid.String())); err != nil {
 				t.Fatalf("data not in receiver store: %v", err)

--- a/p2p/protocol/head/head.go
+++ b/p2p/protocol/head/head.go
@@ -2,13 +2,14 @@ package head
 
 import (
 	"context"
-	logging "github.com/ipfs/go-log/v2"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"path"
 	"sync"
 	"time"
+
+	logging "github.com/ipfs/go-log/v2"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -43,10 +44,10 @@ func (p *Publisher) Serve(host host.Host, topic string) error {
 	pid := deriveProtocolID(topic)
 	l, err := gostream.Listen(host, pid)
 	if err != nil {
-		log.Errorf("Failed to listen to gostream on host %s with prpotocol ID %s", host.ID(), pid)
+		log.Errorf("Failed to listen to gostream on host %s with protocol ID %s", host.ID(), pid)
 		return err
 	}
-	log.Infof("Serving gostream on host %s with prpotocol ID %s", host.ID(), pid)
+	log.Infof("Serving gostream on host %s with protocol ID %s", host.ID(), pid)
 	return p.server.Serve(l)
 }
 

--- a/publish.go
+++ b/publish.go
@@ -2,6 +2,7 @@ package legs
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	dt "github.com/filecoin-project/go-data-transfer"
@@ -71,8 +72,11 @@ func NewPublisherFromExisting(ctx context.Context,
 }
 
 func (lp *legPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
-	log.Debugf("Publishing CID and addresses in pubsub channel: %s", c)
-	var errs error
+	if c == cid.Undef {
+		return errors.New("cannot update to an undefined cid")
+	}
+
+	log.Debugf("Published CID and addresses in pubsub channel: %s", c)
 	err := lp.headPublisher.UpdateRoot(ctx, c)
 	if err != nil {
 		errs = multierror.Append(errs, err)

--- a/publish.go
+++ b/publish.go
@@ -72,6 +72,7 @@ func NewPublisherFromExisting(ctx context.Context,
 }
 
 func (lp *legPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
+	var errs error
 	if c == cid.Undef {
 		return errors.New("cannot update to an undefined cid")
 	}


### PR DESCRIPTION
This also prevents a downstream encoding error where we can not properly encode an undefined CID.

Andrew and I don't think there's any reason why `UpdateRoot` should allow an undefined CID. Do others feel differently?