### PR TITLE
Allow to specify multiaddrs when publishing.

### DIFF
--- a/http/publish.go
+++ b/http/publish.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ipld/go-ipld-prime/codec/dagjson"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 type httpPublisher struct {
@@ -78,6 +79,10 @@ func (h *httpPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
 	defer h.rl.Unlock()
 	h.root = c
 	return nil
+}
+
+func (h *httpPublisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, _ []ma.Multiaddr) error {
+	return h.UpdateRoot(ctx, c)
 }
 
 func (h *httpPublisher) Close() error {

--- a/interface.go
+++ b/interface.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
@@ -16,6 +17,8 @@ import (
 type LegPublisher interface {
 	// Publishes and update for the DAG in the pubsub channel.
 	UpdateRoot(context.Context, cid.Cid) error
+	// Publishes and update for the DAG in the pubsub channel using custom multiaddrs.
+	UpdateRootWithAddrs(context.Context, cid.Cid, []ma.Multiaddr) error
 	// Close publisher
 	Close() error
 }

--- a/interface.go
+++ b/interface.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 // Publish will export an IPLD dag of data publicly for consumption.

--- a/publish.go
+++ b/publish.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
-	ma "github.com/multiformats/go-multiaddr"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	ma "github.com/multiformats/go-multiaddr"
 )
 
 type legPublisher struct {

--- a/publish.go
+++ b/publish.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/host"
+	ma "github.com/multiformats/go-multiaddr"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
@@ -70,10 +71,14 @@ func NewPublisherFromExisting(ctx context.Context,
 }
 
 func (lp *legPublisher) UpdateRoot(ctx context.Context, c cid.Cid) error {
+	return lp.UpdateRootWithAddrs(ctx, c, lp.host.Addrs())
+}
+
+func (lp *legPublisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, addrs []ma.Multiaddr) error {
 	log.Debugf("Published CID and addresses in pubsub channel: %s", c)
 	msg := message{
 		cid:   c,
-		addrs: lp.host.Addrs(),
+		addrs: addrs,
 	}
 	err1 := lp.topic.Publish(ctx, encodeMessage(msg))
 	err2 := lp.headPublisher.UpdateRoot(ctx, c)


### PR DESCRIPTION
This PR modifies the publisher to allow to specify custom multiaddrs when updating the root.