### PR TITLE
Fix flaky tests with direct peers pubsub

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -33,13 +33,6 @@ jobs:
         uses: protocol/multiple-go-modules@v1.2
         with:
           run: go test -v -coverprofile module-coverage.txt ./...
-      - name: Run tests (32 bit)
-        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
-        uses: protocol/multiple-go-modules@v1.2
-        env:
-          GOARCH: 386
-        with:
-          run: go test -v ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2

--- a/broker.go
+++ b/broker.go
@@ -156,8 +156,8 @@ func NewBroker(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, topi
 
 		addrTTL:   cfg.addrTTL,
 		psub:      psub,
-		topic:     pubsubTopic,
-		topicName: pubsubTopic.String(),
+		topic:     cfg.topic,
+		topicName: cfg.topic.String(),
 		closing:   make(chan struct{}),
 		cancelps:  cancelPubsub,
 

--- a/dtsync/option.go
+++ b/dtsync/option.go
@@ -1,0 +1,32 @@
+package dtsync
+
+import (
+	"fmt"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+)
+
+// config contains all options for configuring dtsync.publisher.
+type config struct {
+	topic *pubsub.Topic
+}
+
+type Option func(*config) error
+
+// apply applies the given options to this config.
+func (c *config) apply(opts []Option) error {
+	for i, opt := range opts {
+		if err := opt(c); err != nil {
+			return fmt.Errorf("option %d failed: %s", i, err)
+		}
+	}
+	return nil
+}
+
+// Topic provides an existing pubsub topic.
+func Topic(topic *pubsub.Topic) Option {
+	return func(c *config) error {
+		c.topic = topic
+		return nil
+	}
+}


### PR DESCRIPTION
draft currently to give you the gist. If it looks good, I'll update all the tests to be less flaky:

## Summary
We can create the gossipsub pubsub object with the [pubsub.WithDirectPeers](https://pkg.go.dev/github.com/libp2p/go-libp2p-pubsub#WithDirectPeers) option.
>  all (valid) message unconditionally forwarded to them

This seems ideal for what we want in our test since we aren't trying to test the gossipsub implementation. So to enable that I added a new helper in test/util:

```go
// WaitForMeshWithMessage sets up a gossipsub network and sends a test message.
// Blocks until all other hosts see the first host's message.
func WaitForMeshWithMessage(t *testing.T, topic string, hosts ...host.Host) []*pubsub.Topic {
// ...
}
```

You can give it a topic name and a bunch of hosts, it will make sure the hosts connect to each other, create the pubsub object with the directpeer option, and create the topic. It will then send a test message on the topic and make sure the every other host gets the test message before returning. It uses the given topic to run this test so we know that that topic is ready to be used later on in the tests.

Broker already allows passing in a topic object via the Option. This adds something similar to dtsync publisher.

This mesh forms in ~50ms, so it can really speed up our tests (relative to sleeps in the seconds).

Tested against flakiness by using the `-count` option when running tests.