### PR TITLE
Allow the sync recursion limit to be optionally specified

### DIFF
--- a/option.go
+++ b/option.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	dt "github.com/filecoin-project/go-data-transfer"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
@@ -18,6 +19,8 @@ type config struct {
 	dtManager  dt.Manager
 	blockHook  BlockHookFunc
 	httpClient *http.Client
+
+	syncRecLimit selector.RecursionLimit
 }
 
 type Option func(*config) error
@@ -78,6 +81,15 @@ func HttpClient(client *http.Client) Option {
 func BlockHook(blockHook BlockHookFunc) Option {
 	return func(c *config) error {
 		c.blockHook = blockHook
+		return nil
+	}
+}
+
+// SyncRecursionLimit sets the recursion limit of the background syncing process.
+// Defaults to selector.RecursionLimitNone if not specified.
+func SyncRecursionLimit(limit selector.RecursionLimit) Option {
+	return func(c *config) error {
+		c.syncRecLimit = limit
 		return nil
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,15 @@
+package legs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+)
+
+func TestSyncRecursionLimit_DefaultsToNone(t *testing.T) {
+	cfg := config{}
+	if !reflect.DeepEqual(selector.RecursionLimitNone(), cfg.syncRecLimit) {
+		t.Fail()
+	}
+}

--- a/selector.go
+++ b/selector.go
@@ -58,11 +58,11 @@ func ExploreRecursiveWithStopNode(limit selector.RecursionLimit, sequence ipld.N
 //
 // LegSelector is a "recurse all" selector that provides conditions
 // to stop the traversal at a specific link (stopAt).
-func LegSelector(stopLnk ipld.Link) ipld.Node {
+func LegSelector(limit selector.RecursionLimit, stopLnk ipld.Link) ipld.Node {
 	np := basicnode.Prototype__Any{}
 	ssb := selectorbuilder.NewSelectorSpecBuilder(np)
 	return ExploreRecursiveWithStop(
-		selector.RecursionLimitNone(),
+		limit,
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge()),
 		stopLnk)
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.3"
+  "version": "v0.2.4"
 }


### PR DESCRIPTION
Allow the user to specify the recursion limit for the background syncing
process with default of no limit.

Fixes #34