### PR TITLE
ScopedBlock hook with subscriber.SyncWithHook

### DIFF
--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -35,6 +35,79 @@ type pubMeta struct {
 	h   host.Host
 }
 
+func TestScopedBlockHook(t *testing.T) {
+	err := quick.Check(func(ll llBuilder) bool {
+		return t.Run("Quickcheck", func(t *testing.T) {
+			ds := dssync.MutexWrap(datastore.NewMapDatastore())
+			pubHost := test.MkTestHost()
+			lsys := test.MkLinkSystem(ds)
+			pub, err := dtsync.NewPublisher(pubHost, ds, lsys, testTopic)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			head := ll.Build(t, lsys)
+			if head == nil {
+				// We built an empty list. So nothing to test.
+				return
+			}
+
+			err = pub.UpdateRoot(context.Background(), head.(cidlink.Link).Cid)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			subDS := dssync.MutexWrap(datastore.NewMapDatastore())
+			subLsys := test.MkLinkSystem(subDS)
+			subHost := test.MkTestHost()
+
+			var calledGeneralBlockHookTimes int64
+			sub, err := legs.NewSubscriber(subHost, subDS, subLsys, testTopic, nil, legs.BlockHook(func(i peer.ID, c cid.Cid) {
+				atomic.AddInt64(&calledGeneralBlockHookTimes, 1)
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var calledScopedBlockHookTimes int64
+			_, err = sub.SyncWithHook(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0], func(i peer.ID, c cid.Cid) {
+				atomic.AddInt64(&calledScopedBlockHookTimes, 1)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if atomic.LoadInt64(&calledGeneralBlockHookTimes) != int64(0) {
+				t.Fatalf("Shouldn't have called general block hook. Called %d times", atomic.LoadInt64(&calledGeneralBlockHookTimes))
+			}
+			if atomic.LoadInt64(&calledScopedBlockHookTimes) != int64(ll.Length) {
+				t.Fatalf("Didn't call scoped block hook enough times")
+			}
+
+			anotherLL := llBuilder{
+				Length: ll.Length,
+				Seed:   ll.Seed + 1,
+			}.Build(t, lsys)
+
+			pub.UpdateRoot(context.Background(), anotherLL.(cidlink.Link).Cid)
+			_, err = sub.Sync(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if atomic.LoadInt64(&calledGeneralBlockHookTimes) != int64(ll.Length) {
+				t.Fatalf("Didn't call general block hook enough times")
+			}
+
+		})
+	}, &quick.Config{
+		MaxCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestConcurrentSync(t *testing.T) {
 	err := quick.Check(func(ll llBuilder, publisherCount uint8) bool {
 		return t.Run("Quickcheck", func(t *testing.T) {


### PR DESCRIPTION
Adds the ability to specify a block hook in a `Sync` call, and have that block hook be called for blocks associated with that sync. Could help clean up logic in indexer and usages of block hook in general. 

For example instead of having to keep track of a mapping of entriesCid -> AdCid like we currently do, we could rely on closured variables to get that information. For example:

```go
// in syncAdEntries in linksystem.go in indexer
      
	_, err = ing.sub.Sync(ctx, from, entriesCid, ing.entriesSel, nil, func(_ peer.ID, c cid.Cid) {
		node, err := decodeIPLDNode(c.Prefix().Codec, bytes.NewBuffer(val))
	        if err != nil {
		        log.Errorw("Error decoding ipldNode", "err", err)
		        return
	        }
	    	err = ing.indexContentBlock(adCid, from, node)
	          if err != nil {
		          log.Errorw("Error processing entries for advertisement", "err", err)
	          } else {
		          log.Info("Done indexing content in entry block")
		          ing.signalMetricsUpdate()
	          }
       })
```