### PR TITLE
Add optional miner ID to pubsub message

### DIFF
--- a/dtsync/message.go
+++ b/dtsync/message.go
@@ -87,7 +87,7 @@ func DecodeMessage(data []byte) (Message, error) {
 	if len(data) != 0 {
 		addrCount, n, err := varint.FromUvarint(data)
 		if err != nil {
-			return Message{}, fmt.Errorf("cannot read number of multiadds: %w", err)
+			return Message{}, fmt.Errorf("cannot read number of multiaddrs: %w", err)
 		}
 		if n > len(data) {
 			return Message{}, ErrBadEncoding
@@ -101,7 +101,7 @@ func DecodeMessage(data []byte) (Message, error) {
 			for i := 0; i < int(addrCount); i++ {
 				val, n, err := varint.FromUvarint(data)
 				if err != nil {
-					return Message{}, fmt.Errorf("cannot read multiadds length: %w", err)
+					return Message{}, fmt.Errorf("cannot read multiaddrs length: %w", err)
 				}
 				if n > len(data) {
 					return Message{}, ErrBadEncoding
@@ -113,7 +113,7 @@ func DecodeMessage(data []byte) (Message, error) {
 				}
 				addrs[i], err = multiaddr.NewMultiaddrBytes(data[:val])
 				if err != nil {
-					return Message{}, fmt.Errorf("cannot decode multiadds: %w", err)
+					return Message{}, fmt.Errorf("cannot decode multiaddrs: %w", err)
 				}
 				data = data[val:]
 			}

--- a/dtsync/message.go
+++ b/dtsync/message.go
@@ -2,6 +2,7 @@ package dtsync
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/ipfs/go-cid"
@@ -9,11 +10,24 @@ import (
 	"github.com/multiformats/go-varint"
 )
 
+var ErrBadEncoding = errors.New("invalid message encoding")
+
 type Message struct {
-	Cid   cid.Cid
-	Addrs []multiaddr.Multiaddr
+	Cid       cid.Cid
+	Addrs     []multiaddr.Multiaddr
+	ExtraData []byte `json:",omitempty"`
 }
 
+// EncodeMessage produces a binary encoding of the message. The binary format
+// is as follows:
+//
+//   +----------------------------------------------------+
+//   | CID   | nAddrs | addrLen | addr  | ... | ExtraData |
+//   | bytes | varint | varint  | bytes | ... | bytes     |
+//   +----------------------------------------------------+
+//                    |                 |
+//                    { repeat nAddrs X }
+//
 func EncodeMessage(m Message) []byte {
 	// Get size
 	var size, maxVarintLen int
@@ -27,51 +41,92 @@ func EncodeMessage(m Message) []byte {
 	}
 
 	vibuf := make([]byte, maxVarintLen)
+
+	n := varint.PutUvarint(vibuf, uint64(len(m.Addrs)))
+
 	var b bytes.Buffer
-	b.Grow(m.Cid.ByteLen() + size)
+	b.Grow(m.Cid.ByteLen() + n + size + len(m.ExtraData))
 	// CID already contains encoded length, so no need to add length to data.
 	_, err := m.Cid.WriteBytes(&b)
 	if err != nil {
 		panic(err)
 	}
 
+	// Write number of addrs
+	b.Write(vibuf[:n])
+
 	for _, addr := range m.Addrs {
 		addrBytes := addr.Bytes()
-		n := varint.PutUvarint(vibuf, uint64(len(addrBytes)))
+		n = varint.PutUvarint(vibuf, uint64(len(addrBytes)))
 		b.Write(vibuf[:n])
 		b.Write(addrBytes)
+	}
+
+	if len(m.ExtraData) != 0 {
+		b.Write(m.ExtraData)
 	}
 
 	return b.Bytes()
 }
 
+// DecodeMessage decodes a binary encoded message that was encoded by
+// EncodeMessage.
 func DecodeMessage(data []byte) (Message, error) {
 	n, c, err := cid.CidFromBytes(data)
 	if err != nil {
 		return Message{}, err
 	}
+	if n > len(data) {
+		return Message{}, ErrBadEncoding
+	}
 	data = data[n:]
 
-	// Read multiaddrs if there is any more data in message data.  This allows
-	// backward-compatability with publishers that do not supply address data.
 	var addrs []multiaddr.Multiaddr
-	for len(data) != 0 {
-		val, n, err := varint.FromUvarint(data)
+	var extraData []byte
+
+	if len(data) != 0 {
+		addrCount, n, err := varint.FromUvarint(data)
 		if err != nil {
 			return Message{}, fmt.Errorf("cannot read number of multiadds: %w", err)
 		}
+		if n > len(data) {
+			return Message{}, ErrBadEncoding
+		}
 		data = data[n:]
 
-		addr, err := multiaddr.NewMultiaddrBytes(data[:val])
-		if err != nil {
-			return Message{}, fmt.Errorf("cannot decode multiadds: %w", err)
+		if addrCount != 0 {
+			// Read multiaddrs if there is any more data in message data.  This allows
+			// backward-compatability with publishers that do not supply address data.
+			addrs = make([]multiaddr.Multiaddr, addrCount)
+			for i := 0; i < int(addrCount); i++ {
+				val, n, err := varint.FromUvarint(data)
+				if err != nil {
+					return Message{}, fmt.Errorf("cannot read multiadds length: %w", err)
+				}
+				if n > len(data) {
+					return Message{}, ErrBadEncoding
+				}
+				data = data[n:]
+
+				if len(data) < int(val) {
+					return Message{}, ErrBadEncoding
+				}
+				addrs[i], err = multiaddr.NewMultiaddrBytes(data[:val])
+				if err != nil {
+					return Message{}, fmt.Errorf("cannot decode multiadds: %w", err)
+				}
+				data = data[val:]
+			}
 		}
-		data = data[val:]
-		addrs = append(addrs, addr)
+		if len(data) != 0 {
+			extraData = make([]byte, len(data))
+			copy(extraData, data)
+		}
 	}
 
 	return Message{
-		Cid:   c,
-		Addrs: addrs,
+		Cid:       c,
+		Addrs:     addrs,
+		ExtraData: extraData,
 	}, nil
 }

--- a/dtsync/message_test.go
+++ b/dtsync/message_test.go
@@ -1,6 +1,7 @@
 package dtsync
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -24,8 +25,9 @@ func TestEncodeDecodeMessage(t *testing.T) {
 	}
 
 	msg1 := Message{
-		Cid:   c,
-		Addrs: []multiaddr.Multiaddr{maddrA, maddrB},
+		Cid:       c,
+		Addrs:     []multiaddr.Multiaddr{maddrA, maddrB},
+		ExtraData: []byte("hello"),
 	}
 
 	data := EncodeMessage(msg1)
@@ -46,5 +48,8 @@ func TestEncodeDecodeMessage(t *testing.T) {
 		if !msg2.Addrs[i].Equal(msg1.Addrs[i]) {
 			t.Fatalf("Decoded multiaddr %d %q is not equal to original %q", i, msg2.Addrs[i], msg1.Addrs[i])
 		}
+	}
+	if !bytes.Equal(msg2.ExtraData, msg1.ExtraData) {
+		t.Fatal("Wrong ExtraData")
 	}
 }

--- a/dtsync/option.go
+++ b/dtsync/option.go
@@ -24,8 +24,8 @@ func (c *config) apply(opts []Option) error {
 	return nil
 }
 
-// MinerID sets a miner ID to include in the pubsub message.
-func MinerID(minerID string) Option {
+// WithMinerID sets a miner ID to include in the pubsub message.
+func WithMinerID(minerID string) Option {
 	return func(c *config) error {
 		c.minerID = minerID
 		return nil

--- a/dtsync/option.go
+++ b/dtsync/option.go
@@ -8,8 +8,8 @@ import (
 
 // config contains all options for configuring dtsync.publisher.
 type config struct {
-	minerID string
-	topic   *pubsub.Topic
+	extraData []byte
+	topic     *pubsub.Topic
 }
 
 type Option func(*config) error
@@ -24,10 +24,12 @@ func (c *config) apply(opts []Option) error {
 	return nil
 }
 
-// WithMinerID sets a miner ID to include in the pubsub message.
-func WithMinerID(minerID string) Option {
+// WithExtraData sets the extra data to include in the pubsub message.
+func WithExtraData(data []byte) Option {
 	return func(c *config) error {
-		c.minerID = minerID
+		if len(data) != 0 {
+			c.extraData = data
+		}
 		return nil
 	}
 }

--- a/dtsync/option.go
+++ b/dtsync/option.go
@@ -8,7 +8,8 @@ import (
 
 // config contains all options for configuring dtsync.publisher.
 type config struct {
-	topic *pubsub.Topic
+	minerID string
+	topic   *pubsub.Topic
 }
 
 type Option func(*config) error
@@ -21,6 +22,14 @@ func (c *config) apply(opts []Option) error {
 		}
 	}
 	return nil
+}
+
+// MinerID sets a miner ID to include in the pubsub message.
+func MinerID(minerID string) Option {
+	return func(c *config) error {
+		c.minerID = minerID
+		return nil
+	}
 }
 
 // Topic provides an existing pubsub topic.

--- a/dtsync/publisher.go
+++ b/dtsync/publisher.go
@@ -27,6 +27,7 @@ type publisher struct {
 	dtClose       dtCloseFunc
 	headPublisher *head.Publisher
 	host          host.Host
+	minerID       []byte
 	topic         *pubsub.Topic
 }
 
@@ -69,6 +70,7 @@ func NewPublisher(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, t
 		dtClose:       dtClose,
 		headPublisher: headPublisher,
 		host:          host,
+		minerID:       []byte(cfg.minerID),
 		topic:         t,
 	}, nil
 }
@@ -119,6 +121,7 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topic string
 		cancelPubSub:  cancel,
 		headPublisher: headPublisher,
 		host:          host,
+		minerID:       []byte(cfg.minerID),
 		topic:         t,
 	}, nil
 }
@@ -142,8 +145,9 @@ func (p *publisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, addrs []
 	}
 	log.Debugf("Publishing CID and addresses in pubsub channel: %s", c)
 	msg := Message{
-		Cid:   c,
-		Addrs: addrs,
+		Cid:       c,
+		Addrs:     addrs,
+		ExtraData: p.minerID,
 	}
 	return p.topic.Publish(ctx, EncodeMessage(msg))
 }

--- a/dtsync/publisher.go
+++ b/dtsync/publisher.go
@@ -64,15 +64,19 @@ func NewPublisher(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, t
 	headPublisher := head.NewPublisher()
 	startHeadPublisher(host, topic, headPublisher)
 
-	return &publisher{
+	p := &publisher{
 		cancelPubSub:  cancel,
 		dtManager:     dtManager,
 		dtClose:       dtClose,
 		headPublisher: headPublisher,
 		host:          host,
-		minerID:       []byte(cfg.minerID),
 		topic:         t,
-	}, nil
+	}
+
+	if cfg.minerID != "" {
+		p.minerID = []byte(cfg.minerID)
+	}
+	return p, nil
 }
 
 func startHeadPublisher(host host.Host, topic string, headPublisher *head.Publisher) {
@@ -117,13 +121,17 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topic string
 	headPublisher := head.NewPublisher()
 	startHeadPublisher(host, topic, headPublisher)
 
-	return &publisher{
+	p := &publisher{
 		cancelPubSub:  cancel,
 		headPublisher: headPublisher,
 		host:          host,
-		minerID:       []byte(cfg.minerID),
 		topic:         t,
-	}, nil
+	}
+
+	if cfg.minerID != "" {
+		p.minerID = []byte(cfg.minerID)
+	}
+	return p, nil
 }
 
 func (p *publisher) SetRoot(ctx context.Context, c cid.Cid) error {

--- a/dtsync/publisher.go
+++ b/dtsync/publisher.go
@@ -27,7 +27,7 @@ type publisher struct {
 	dtClose       dtCloseFunc
 	headPublisher *head.Publisher
 	host          host.Host
-	minerID       []byte
+	extraData     []byte
 	topic         *pubsub.Topic
 }
 
@@ -73,8 +73,8 @@ func NewPublisher(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, t
 		topic:         t,
 	}
 
-	if cfg.minerID != "" {
-		p.minerID = []byte(cfg.minerID)
+	if len(cfg.extraData) != 0 {
+		p.extraData = cfg.extraData
 	}
 	return p, nil
 }
@@ -128,8 +128,8 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topic string
 		topic:         t,
 	}
 
-	if cfg.minerID != "" {
-		p.minerID = []byte(cfg.minerID)
+	if len(cfg.extraData) != 0 {
+		p.extraData = cfg.extraData
 	}
 	return p, nil
 }
@@ -155,7 +155,7 @@ func (p *publisher) UpdateRootWithAddrs(ctx context.Context, c cid.Cid, addrs []
 	msg := Message{
 		Cid:       c,
 		Addrs:     addrs,
-		ExtraData: p.minerID,
+		ExtraData: p.extraData,
 	}
 	return p.topic.Publish(ctx, EncodeMessage(msg))
 }

--- a/legs_test.go
+++ b/legs_test.go
@@ -46,7 +46,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]), dtsync.MinerID("t01000"))
+	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]), dtsync.WithMinerID("t01000"))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/legs_test.go
+++ b/legs_test.go
@@ -46,7 +46,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]))
+	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]), dtsync.MinerID("t01000"))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/legs_test.go
+++ b/legs_test.go
@@ -46,7 +46,7 @@ func initPubSub(t *testing.T, srcStore, dstStore datastore.Batching) (host.Host,
 
 	srcLnkS := test.MkLinkSystem(srcStore)
 
-	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]), dtsync.WithMinerID("t01000"))
+	pub, err := dtsync.NewPublisher(srcHost, srcStore, srcLnkS, testTopic, dtsync.Topic(topics[0]), dtsync.WithExtraData([]byte("t01000")))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.7"
+  "version": "v0.2.8"
 }


### PR DESCRIPTION
By carrying the miner ID in the pubsub message the lotus chain-nodes that relay the messages can lookup the merket process peer ID and ensure that was the peer that signed the message.  This authenticates the message as being sent from a peer that is known on-chain.