### PR TITLE
Adds SyncOption to subscriber

### DIFF
--- a/option.go
+++ b/option.go
@@ -85,3 +85,22 @@ func SyncRecursionLimit(limit selector.RecursionLimit) Option {
 		return nil
 	}
 }
+
+type syncCfg struct {
+	scopedBlockHook    BlockHookFunc
+	alwaysUpdateLatest bool
+}
+
+type SyncOption func(*syncCfg)
+
+func ScopedBlockHook(hook BlockHookFunc) SyncOption {
+	return func(sc *syncCfg) {
+		sc.scopedBlockHook = hook
+	}
+}
+
+func AlwaysUpdateLatest() SyncOption {
+	return func(sc *syncCfg) {
+		sc.alwaysUpdateLatest = true
+	}
+}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -76,9 +76,9 @@ func TestScopedBlockHook(t *testing.T) {
 			}
 
 			var calledScopedBlockHookTimes int64
-			_, err = sub.SyncWithHook(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0], func(i peer.ID, c cid.Cid) {
+			_, err = sub.Sync(context.Background(), pubHost.ID(), cid.Undef, nil, pubHost.Addrs()[0], legs.ScopedBlockHook(func(i peer.ID, c cid.Cid) {
 				atomic.AddInt64(&calledScopedBlockHookTimes, 1)
-			})
+			}))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Gives access to pass in a scoped block hook or always update the latest seen cid for a peer. Context here: https://github.com/filecoin-project/storetheindex/pull/224/commits/f069cd56d2b5e882150189901e88878515eb6314#diff-50d2db719b550ec2183b831d2727d9184635a5647247ea8872ff82d91b6e31bdR283 and https://github.com/filecoin-project/storetheindex/pull/224#discussion_r812311217
