### PR TITLE
Add CheckAlreadySynced sync option

### DIFF
--- a/option.go
+++ b/option.go
@@ -87,18 +87,12 @@ func SyncRecursionLimit(limit selector.RecursionLimit) Option {
 }
 
 type syncCfg struct {
-	scopedBlockHook    BlockHookFunc
 	alwaysUpdateLatest bool
 	checkAlreadySynced bool
+	scopedBlockHook    BlockHookFunc
 }
 
 type SyncOption func(*syncCfg)
-
-func ScopedBlockHook(hook BlockHookFunc) SyncOption {
-	return func(sc *syncCfg) {
-		sc.scopedBlockHook = hook
-	}
-}
 
 func AlwaysUpdateLatest() SyncOption {
 	return func(sc *syncCfg) {
@@ -113,5 +107,11 @@ func AlwaysUpdateLatest() SyncOption {
 func CheckAlreadySynced() SyncOption {
 	return func(sc *syncCfg) {
 		sc.checkAlreadySynced = true
+	}
+}
+
+func ScopedBlockHook(hook BlockHookFunc) SyncOption {
+	return func(sc *syncCfg) {
+		sc.scopedBlockHook = hook
 	}
 }

--- a/option.go
+++ b/option.go
@@ -89,6 +89,7 @@ func SyncRecursionLimit(limit selector.RecursionLimit) Option {
 type syncCfg struct {
 	scopedBlockHook    BlockHookFunc
 	alwaysUpdateLatest bool
+	checkAlreadySynced bool
 }
 
 type SyncOption func(*syncCfg)
@@ -102,5 +103,15 @@ func ScopedBlockHook(hook BlockHookFunc) SyncOption {
 func AlwaysUpdateLatest() SyncOption {
 	return func(sc *syncCfg) {
 		sc.alwaysUpdateLatest = true
+	}
+}
+
+// CheckAlreadySynced is used when a custom selector is provided, and checks if
+// the head node returned from the publisher is the latest seen.  This is
+// needed because a selector with a stop node only recognizes if the previous
+// link is the stop, not if the current node is.
+func CheckAlreadySynced() SyncOption {
+	return func(sc *syncCfg) {
+		sc.checkAlreadySynced = true
 	}
 }

--- a/subscriber.go
+++ b/subscriber.go
@@ -478,7 +478,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 	hnd.syncMutex.Lock()
 	defer hnd.syncMutex.Unlock()
 
-	err = hnd.handle(ctx, nextCid, sel, wrapSel, updateLatest, syncer, cfg.scopedBlockHook)
+	err = hnd.handle(ctx, nextCid, sel, wrapSel, updateLatest, syncer, cfg.scopedBlockHook, cfg.checkAlreadySynced)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("sync handler failed: %w", err)
 	}
@@ -643,7 +643,7 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 		select {
 		case <-ctx.Done():
 		case c := <-h.msgChan:
-			err := h.handle(ctx, c, ss, true, true, h.subscriber.dtSync.NewSyncer(h.peerID, h.subscriber.topicName), nil)
+			err := h.handle(ctx, c, ss, true, true, h.subscriber.dtSync.NewSyncer(h.peerID, h.subscriber.topicName), nil, false)
 			if err != nil {
 				// Log error for now.
 				log.Errorw("Cannot process message", "err", err, "peer", h.peerID)
@@ -660,7 +660,7 @@ func (h *handler) handleAsync(ctx context.Context, nextCid cid.Cid, ss ipld.Node
 // handle processes a message from the peer that the handler is responsible for.
 // The caller is responsible for ensuring that this is called while h.syncMutex
 // is locked.
-func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer, hook BlockHookFunc) error {
+func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wrapSel, updateLatest bool, syncer Syncer, hook BlockHookFunc, checkAlreadySynced bool) error {
 	log := log.With("cid", nextCid, "peer", h.peerID)
 
 	// This is not set to nil so we can get a pointer.
@@ -677,16 +677,25 @@ func (h *handler) handle(ctx context.Context, nextCid cid.Cid, sel ipld.Node, wr
 
 	if wrapSel {
 		// Note this branch is nested under wrapSel because wrapSel adds the
-		// semantics that we stop when we hit the `h.latestSync` node. This is a
-		// special case where we are starting at the stop node so we can just
+		// semantics that we stop when we hit the `h.latestSync` node. This is
+		// a special case where we are starting at the stop node so we can just
 		// return.
 		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
-			// Nothing to do. We've already synced to this cid because we have it as h.latestSync.
+			// Nothing to do. We've already synced to this cid because we have
+			// it as h.latestSync.
 			log.Infow("Already synced")
 			return nil
 		}
 
 		sel = ExploreRecursiveWithStopNode(h.subscriber.syncRecLimit, sel, h.latestSync)
+	} else if checkAlreadySynced {
+		// Special case when starting at stop node; selector does not check it.
+		if h.latestSync != nil && h.latestSync.(cidlink.Link).Cid == nextCid {
+			// Nothing to do. We've already synced to this cid because we have
+			// it as h.latestSync.
+			log.Infow("Already synced")
+			return nil
+		}
 	}
 
 	err := syncer.Sync(ctx, nextCid, sel)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.3"
+  "version": "v0.3.4"
 }


### PR DESCRIPTION
This is necessary to check if already synced to the current head, when a custom selector is passed in.  If the selector has a stop node, the selector only compares the previous link against the stop node.  So, if the current head is the stop node, this needs a special case check.  Normally, when a custom selector is passed in this special case check is not done (since legs does not know what the selector does).  This option lets the caller tell legs to do the special case check.