### PR TITLE
Change temporary address TTL

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -176,12 +176,6 @@ func (s *Sync) onEvent(event dt.Event, channelState dt.ChannelState) {
 		if strings.HasSuffix(msg, "content not found") {
 			err = errors.New(err.Error() + ": content not found")
 		}
-	case dt.Ongoing:
-		if channelState.Message() != "stream reset" {
-			return
-		}
-		log.Warnw("Detected stream reset from peer", "peer", channelState.OtherPeer())
-		err = errors.New("stream reset")
 	default:
 		// Ignore non-terminal channel states.
 		return

--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -176,6 +176,12 @@ func (s *Sync) onEvent(event dt.Event, channelState dt.ChannelState) {
 		if strings.HasSuffix(msg, "content not found") {
 			err = errors.New(err.Error() + ": content not found")
 		}
+	case dt.Ongoing:
+		if channelState.Message() != "stream reset" {
+			return
+		}
+		log.Warnw("Detected stream reset from peer", "peer", channelState.OtherPeer())
+		err = errors.New("stream reset")
 	default:
 		// Ignore non-terminal channel states.
 		return

--- a/subscriber.go
+++ b/subscriber.go
@@ -31,7 +31,10 @@ var log = logging.Logger("go-legs")
 // defaultAddrTTL is the default amount of time that addresses discovered from
 // pubsub messages will remain in the peerstore.  This is twice the default
 // provider poll interval.
-const defaultAddrTTL = 48 * time.Hour
+const (
+	defaultAddrTTL = 48 * time.Hour
+	tempAddrTTL    = 24 * time.Hour // must be long enough for ad chain to sync
+)
 
 // errSourceNotAllowed is the error returned when a message source peer's
 // messages is not allowed to be processed.  This is only used internally, and
@@ -434,7 +437,7 @@ func (s *Subscriber) Sync(ctx context.Context, peerID peer.ID, nextCid cid.Cid, 
 		// decrease the TTL here.
 		peerStore := s.host.Peerstore()
 		if peerStore != nil {
-			peerStore.AddAddr(peerID, peerAddr, peerstore.TempAddrTTL)
+			peerStore.AddAddr(peerID, peerAddr, tempAddrTTL)
 		}
 		syncer = s.dtSync.NewSyncer(peerID, s.topicName)
 	}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.6"
+  "version": "v0.3.7"
 }


### PR DESCRIPTION
Once there is a stream reset, there will not be any more datatransfer events, so it must be streated as a terminal state.

Use a much longer TTL for temporary addresses, so they remain in the peersotre until the (very long) ad chain is completely synced.