### PR TITLE
Fix possible deadlock if user places backpressure

### DIFF
--- a/subscriber.go
+++ b/subscriber.go
@@ -136,10 +136,9 @@ type handler struct {
 	// syncMutex serializes the handling of individual syncs. This should only
 	// guard the actual handling of a sync, nothing else.
 	syncMutex sync.Mutex
-	// When grabbing this lock, make sure to encompass the syncMutex. It's
-	// incorrect to grab this lock only while updating latestSync. You must hold
-	// this lock while syncing to the next latestSync. Otherwise another process
-	// may overwrite your state.
+	// If updating this from the result of a sync make sure you grab this lock
+	// before calling handler.handle(). Otherwise another process may overwrite
+	// your state.
 	latestSyncMu sync.Mutex
 	latestSync   ipld.Link
 	msgChan      chan cid.Cid


### PR DESCRIPTION
## Context
If a user placed backpressure by not pulling on the OnSyncFinished eventchannel then we would prevent any handler from running for thatpublisher.

This could lead to a deadlock like the one in storetheindex. Where the indexer applies backpressure if the ingest workers cannot keep up. The ingest workers were deadlocked because they could not finish their work because it required another call to `subscriber.Sync` to fetch the ad entries. But the sync was blocked on a handler that was blocked on sending to a channel that was blocked by the indexer pulling the channel that was blocked by not having a worker available to send work to that was blocked by the worker not being to make progress...

## Proposed change

Introduce a new lock that protects around setting the latestSync and sending updates SyncFinished events. And limit the scope of the syncMutex to _only_ the part that needs to actually do the syncing. This means that even if legs is blocked by backpressure, it can still do a specific selector/non-updateLatest sync if requested. In the indexer use-case this allows workers to make progress while still being able to apply back-pressure.
