### PR TITLE
Option for publisher to allow/reject data transfers

### DIFF
--- a/dtsync/option.go
+++ b/dtsync/option.go
@@ -3,6 +3,7 @@ package dtsync
 import (
 	"fmt"
 
+	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
@@ -10,6 +11,7 @@ import (
 type config struct {
 	extraData []byte
 	topic     *pubsub.Topic
+	allowPeer func(peer.ID) bool
 }
 
 type Option func(*config) error
@@ -38,6 +40,15 @@ func WithExtraData(data []byte) Option {
 func Topic(topic *pubsub.Topic) Option {
 	return func(c *config) error {
 		c.topic = topic
+		return nil
+	}
+}
+
+// AllowPeer sets the function that determines whether to allow or reject
+// graphsync sessions from a peer.
+func AllowPeer(allowPeer func(peer.ID) bool) Option {
+	return func(c *config) error {
+		c.allowPeer = allowPeer
 		return nil
 	}
 }

--- a/dtsync/publisher.go
+++ b/dtsync/publisher.go
@@ -54,7 +54,7 @@ func NewPublisher(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, t
 		}
 	}
 
-	dtManager, _, dtClose, err := makeDataTransfer(host, ds, lsys)
+	dtManager, _, dtClose, err := makeDataTransfer(host, ds, lsys, cfg.allowPeer)
 	if err != nil {
 		if cancel != nil {
 			cancel()
@@ -112,7 +112,7 @@ func NewPublisherFromExisting(dtManager dt.Manager, host host.Host, topic string
 		}
 	}
 
-	err = configureDataTransferForLegs(context.Background(), dtManager, lsys)
+	err = configureDataTransferForLegs(context.Background(), dtManager, lsys, cfg.allowPeer)
 	if err != nil {
 		if cancel != nil {
 			cancel()

--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -64,7 +64,7 @@ func (s *Sync) wrapRateLimiterFor(limiterFor rateLimiterFor) rateLimiterFor {
 // NewSyncWithDT creates a new Sync with a datatransfer.Manager provided by the
 // caller.
 func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExchange, blockHook func(peer.ID, cid.Cid), limiterFor rateLimiterFor) (*Sync, error) {
-	registerVoucher(dtManager)
+	registerVoucher(dtManager, &Voucher{}, nil)
 	s := &Sync{
 		host:                   host,
 		dtManager:              dtManager,
@@ -85,7 +85,7 @@ type rateLimiterFor = func(publisher peer.ID) *rate.Limiter
 
 // NewSync creates a new Sync with its own datatransfer.Manager.
 func NewSync(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, blockHook func(peer.ID, cid.Cid), limiterFor rateLimiterFor) (*Sync, error) {
-	dtManager, gs, dtClose, err := makeDataTransfer(host, ds, lsys)
+	dtManager, gs, dtClose, err := makeDataTransfer(host, ds, lsys, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/dtsync/voucher.go
+++ b/dtsync/voucher.go
@@ -47,6 +47,7 @@ func (v *VoucherResult) Type() datatransfer.TypeIdentifier {
 type legsValidator struct {
 	//ctx context.Context
 	//ValidationsReceived chan receivedValidation
+	allowPeer func(peer.ID) bool
 }
 
 func (vl *legsValidator) ValidatePush(
@@ -64,7 +65,7 @@ func (vl *legsValidator) ValidatePush(
 func (vl *legsValidator) ValidatePull(
 	_ bool,
 	_ datatransfer.ChannelID,
-	_ peer.ID,
+	peerID peer.ID,
 	voucher datatransfer.Voucher,
 	_ cid.Cid,
 	_ ipld.Node) (datatransfer.VoucherResult, error) {
@@ -72,6 +73,10 @@ func (vl *legsValidator) ValidatePull(
 	v := voucher.(*Voucher)
 	if v.Head == nil {
 		return nil, errors.New("invalid")
+	}
+
+	if vl.allowPeer != nil && !vl.allowPeer(peerID) {
+		return nil, errors.New("peer not allowed")
 	}
 
 	return &VoucherResult{}, nil

--- a/legs_test.go
+++ b/legs_test.go
@@ -184,7 +184,7 @@ func TestPublisherRejectsPeer(t *testing.T) {
 	case <-time.After(updateTimeout):
 		t.Log("publisher blocked", blockID)
 	case <-watcher:
-		t.Fatal("sync should not have happened with blocker ID")
+		t.Fatal("sync should not have happened with blocked ID")
 	}
 
 	blockID = peer.ID("")


### PR DESCRIPTION
Adds a new dysync.Publisher option to supply a function that determines whether or not to allow data transfers with a peer.

Fixes #20