### PR TITLE
Implement the ability to sync a DAG in segments of configurable depth

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -81,7 +81,7 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []legs.Option) htt
 func TestManualSync(t *testing.T) {
 
 	blocksSeenByHook := make(map[cid.Cid]struct{})
-	blockHook := func(p peer.ID, c cid.Cid) {
+	blockHook := func(p peer.ID, c cid.Cid, _ legs.SegmentSyncActions) {
 		blocksSeenByHook[c] = struct{}{}
 		t.Log("http block hook got", c, "from", p)
 	}
@@ -150,7 +150,7 @@ func TestSyncHttpFailsUnexpectedPeer(t *testing.T) {
 func TestSyncFnHttp(t *testing.T) {
 	var blockHookCalls int
 	blocksSeenByHook := make(map[cid.Cid]struct{})
-	blockHook := func(_ peer.ID, c cid.Cid) {
+	blockHook := func(_ peer.ID, c cid.Cid, _ legs.SegmentSyncActions) {
 		blockHookCalls++
 		blocksSeenByHook[c] = struct{}{}
 	}

--- a/interface.go
+++ b/interface.go
@@ -14,7 +14,7 @@ type Publisher interface {
 	SetRoot(context.Context, cid.Cid) error
 	// UpdateRoot sets the root CID and publishes its update in the pubsub channel.
 	UpdateRoot(context.Context, cid.Cid) error
-	// Publishes an update for the DAG in the pubsub channel using custom multiaddrs.
+	// UpdateRootWithAddrs publishes an update for the DAG in the pubsub channel using custom multiaddrs.
 	UpdateRootWithAddrs(context.Context, cid.Cid, []ma.Multiaddr) error
 	// Close publisher
 	Close() error

--- a/selector.go
+++ b/selector.go
@@ -75,6 +75,102 @@ func getStopNode(selNode datamodel.Node) (datamodel.Link, bool) {
 	return stopNodeLink, err == nil
 }
 
+// getRecursionLimit gets the top-most recursion limit from the given selector node.
+// If no such selector is found, the returned bool will be false.
+func getRecursionLimit(selNode datamodel.Node) (selector.RecursionLimit, bool) {
+	if selNode == nil {
+		return selector.RecursionLimit{}, false
+	}
+	selNode, err := selNode.LookupByString(selector.SelectorKey_ExploreRecursive)
+	if err != nil {
+		return selector.RecursionLimit{}, false
+	}
+	selNode, err = selNode.LookupByString(selector.SelectorKey_Limit)
+	if err != nil {
+		return selector.RecursionLimit{}, false
+	}
+	dln, err := selNode.LookupByString(selector.SelectorKey_LimitDepth)
+	if err != nil {
+		if _, ok := err.(datamodel.ErrNotExists); ok {
+			_, err = selNode.LookupByString(selector.SelectorKey_LimitNone)
+			if err == nil {
+				return selector.RecursionLimitNone(), true
+			}
+		}
+		return selector.RecursionLimit{}, false
+	}
+	dl, err := dln.AsInt()
+	if err != nil {
+		return selector.RecursionLimit{}, false
+	}
+	return selector.RecursionLimitDepth(dl), true
+}
+
+// withRecursionLimit changes the top-most recursion limit for the given selector.
+// If no such recursion limit is present in the given selector, returns nil with false bool.
+func withRecursionLimit(selNode datamodel.Node, rl selector.RecursionLimit) (datamodel.Node, bool) {
+	if selNode == nil {
+		return nil, false
+	}
+
+	// Expect exactly one root entry since the selector returned will only have one.
+	if selNode.Length() != 1 {
+		return nil, false
+	}
+
+	// Expect the entry to be explore recursive.
+	ern, err := selNode.LookupByString(selector.SelectorKey_ExploreRecursive)
+	if err != nil {
+		return nil, false
+	}
+
+	// Store errors that may occur during map iteration to return later.
+	var iErr error
+	selWithLimit := fluent.MustBuildMap(basicnode.Prototype.Any, 1, func(na fluent.MapAssembler) {
+		// Set the recursion limit.
+		na.AssembleEntry(selector.SelectorKey_ExploreRecursive).CreateMap(3, func(na fluent.MapAssembler) {
+			na.AssembleEntry(selector.SelectorKey_Limit).CreateMap(1, func(na fluent.MapAssembler) {
+				switch rl.Mode() {
+				case selector.RecursionLimit_Depth:
+					na.AssembleEntry(selector.SelectorKey_LimitDepth).AssignInt(rl.Depth())
+				case selector.RecursionLimit_None:
+					na.AssembleEntry(selector.SelectorKey_LimitNone).CreateMap(0, func(na fluent.MapAssembler) {})
+				default:
+					panic("Unsupported recursion limit type")
+				}
+			})
+
+			// Add any remaining entries from the original selector, except recursion limit.
+			mi := ern.MapIterator()
+			var k, v ipld.Node
+			var ks string
+			for !mi.Done() {
+				k, v, iErr = mi.Next()
+				if iErr != nil {
+					return
+				}
+
+				// If key is a string, then check that it is not a limit selector key.
+				if k.Kind() == ipld.Kind_String {
+					ks, iErr = k.AsString()
+					if iErr != nil {
+						return
+					}
+					if ks == selector.SelectorKey_Limit {
+						continue
+					}
+				}
+				na.AssembleKey().AssignNode(k)
+				na.AssembleValue().AssignNode(v)
+			}
+		})
+	})
+	if iErr != nil {
+		return nil, false
+	}
+	return selWithLimit, true
+}
+
 // LegSelector is a convenient function that returns the selector
 // used by leg subscribers
 //

--- a/selector_test.go
+++ b/selector_test.go
@@ -3,9 +3,14 @@ package legs
 import (
 	"testing"
 
+	"github.com/filecoin-project/go-legs/test"
 	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,4 +28,144 @@ func TestGetStopNodeWhenNil(t *testing.T) {
 	sel := ExploreRecursiveWithStopNode(selector.RecursionLimitNone(), nil, nil)
 	_, ok := getStopNode(sel)
 	require.False(t, ok, "We shouldn't get a stop node out if none was set")
+}
+
+func TestGetRecursionLimit(t *testing.T) {
+	testCid, err := test.RandomCids(1)
+	require.NoError(t, err)
+	testStopLink := cidlink.Link{Cid: testCid[0]}
+	ssb := selectorbuilder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+	tests := []struct {
+		name          string
+		givenSelector ipld.Node
+		wantFound     bool
+		wantLimit     selector.RecursionLimit
+	}{
+		{
+			name:          "no limit is not found",
+			givenSelector: ssb.ExploreAll(ssb.Matcher()).Node(),
+		},
+		{
+			name:          "unlimited is found",
+			givenSelector: ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreRecursiveEdge()).Node(),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitNone(),
+		},
+		{
+			name:          "limited to zero is found",
+			givenSelector: ssb.ExploreRecursive(selector.RecursionLimitDepth(0), ssb.ExploreRecursiveEdge()).Node(),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitDepth(0),
+		},
+		{
+			name:          "limited to non-zero is found",
+			givenSelector: ssb.ExploreRecursive(selector.RecursionLimitDepth(42), ssb.ExploreRecursiveEdge()).Node(),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitDepth(42),
+		},
+		{
+			name:          "unlimited without stop node is found",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitNone(), ssb.Matcher(), nil),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitNone(),
+		},
+		{
+			name:          "unlimited with stop node is found",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitNone(), ssb.Matcher(), testStopLink),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitNone(),
+		},
+		{
+			name:          "limited without stop node is found",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitDepth(55), ssb.Matcher(), nil),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitDepth(55),
+		},
+		{
+			name:          "unlimited without stop node is found",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitDepth(68), ssb.Matcher(), testStopLink),
+			wantFound:     true,
+			wantLimit:     selector.RecursionLimitDepth(68),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotLimit, gotFound := getRecursionLimit(tt.givenSelector)
+			require.Equal(t, tt.wantFound, gotFound)
+			require.Equal(t, tt.wantLimit, gotLimit)
+		})
+	}
+}
+
+func TestWithRecursionLimit(t *testing.T) {
+	testCid, err := test.RandomCids(1)
+	require.NoError(t, err)
+	testStopLink := cidlink.Link{Cid: testCid[0]}
+	ssb := selectorbuilder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+	tests := []struct {
+		name          string
+		givenSelector ipld.Node
+		givenLimit    selector.RecursionLimit
+		wantApplied   bool
+		wantSelector  ipld.Node
+	}{
+		{
+			name:          "limit is not added to selector with no explore recursive",
+			givenSelector: ssb.ExploreAll(ssb.Matcher()).Node(),
+		},
+		{
+			name:          "same limit is applied",
+			givenSelector: ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreRecursiveEdge()).Node(),
+			givenLimit:    selector.RecursionLimitNone(),
+			wantApplied:   true,
+			wantSelector:  ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreRecursiveEdge()).Node(),
+		},
+		{
+			name:          "different limit is applied",
+			givenSelector: ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreRecursiveEdge()).Node(),
+			givenLimit:    selector.RecursionLimitDepth(45),
+			wantApplied:   true,
+			wantSelector:  ssb.ExploreRecursive(selector.RecursionLimitDepth(45), ssb.ExploreRecursiveEdge()).Node(),
+		},
+		{
+			name: "different limit with complex sequence is applied",
+			givenSelector: ssb.ExploreRecursive(
+				selector.RecursionLimitDepth(1413),
+				ssb.ExploreFields(func(efs selectorbuilder.ExploreFieldsSpecBuilder) {
+					efs.Insert("fish", ssb.ExploreRecursiveEdge())
+					efs.Insert("lobster", ssb.ExploreRange(2, 3, ssb.ExploreRecursiveEdge()))
+				})).Node(),
+			givenLimit:  selector.RecursionLimitNone(),
+			wantApplied: true,
+			wantSelector: ssb.ExploreRecursive(
+				selector.RecursionLimitNone(),
+				ssb.ExploreFields(func(efs selectorbuilder.ExploreFieldsSpecBuilder) {
+					efs.Insert("fish", ssb.ExploreRecursiveEdge())
+					efs.Insert("lobster", ssb.ExploreRange(2, 3, ssb.ExploreRecursiveEdge()))
+				})).Node(),
+		},
+		{
+			name:          "unlimited without stop node is applied",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitNone(), ssb.Matcher(), nil),
+			givenLimit:    selector.RecursionLimitDepth(1413),
+			wantApplied:   true,
+			wantSelector:  ExploreRecursiveWithStop(selector.RecursionLimitDepth(1413), ssb.Matcher(), nil),
+		},
+		{
+			name:          "unlimited with stop node is applied",
+			givenSelector: ExploreRecursiveWithStop(selector.RecursionLimitNone(), ssb.Matcher(), testStopLink),
+			givenLimit:    selector.RecursionLimitDepth(1413),
+			wantApplied:   true,
+			wantSelector:  ExploreRecursiveWithStop(selector.RecursionLimitDepth(1413), ssb.Matcher(), testStopLink),
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotSelector, gotApplied := withRecursionLimit(tt.givenSelector, tt.givenLimit)
+			require.Equal(t, tt.wantApplied, gotApplied)
+			require.True(t, datamodel.DeepEqual(tt.wantSelector, gotSelector))
+		})
+	}
 }

--- a/sync_test.go
+++ b/sync_test.go
@@ -85,7 +85,7 @@ func TestSyncFn(t *testing.T) {
 
 	var blockHookCalls int
 	blocksSeenByHook := make(map[cid.Cid]struct{})
-	blockHook := func(_ peer.ID, c cid.Cid) {
+	blockHook := func(_ peer.ID, c cid.Cid, _ legs.SegmentSyncActions) {
 		blockHookCalls++
 		blocksSeenByHook[c] = struct{}{}
 	}
@@ -106,7 +106,7 @@ func TestSyncFn(t *testing.T) {
 	watcher, cancelWatcher := sub.OnSyncFinished()
 	defer cancelWatcher()
 
-	// Try to sync with a non-existing cid to chack that sync returns with err,
+	// Try to sync with a non-existing cid to check that sync returns with err,
 	// and SyncFinished watcher does not get event.
 	cids, _ := test.RandomCids(1)
 	ctx, syncncl := context.WithTimeout(context.Background(), updateTimeout)
@@ -267,6 +267,7 @@ func TestPartialSync(t *testing.T) {
 		t.Fatalf("data should not be in receiver store: %v", err)
 	}
 }
+
 func TestStepByStepSync(t *testing.T) {
 	srcStore := dssync.MutexWrap(datastore.NewMapDatastore())
 	dstStore := dssync.MutexWrap(datastore.NewMapDatastore())


### PR DESCRIPTION
Syncing very large DAGs in a single sync call, either via `httpsync` or
`dtsync` can result in excessive memory usage doe to internal state
stored by underlying sync mechanism. For example, `httpsync` keeps the
traversed path in memory, which can result in high memory usage when the
syncing excessively large dags.

To avoid such issues, break up the syncing of a DAG into a series of
individual syncs with a smaller and configurable depth limit. This would
then provide an opportunity for any ephemeral state stored in memory
within each sync to be garbage collected, reducing the overall memory
footprint when syncing large DAGs.

The changes introduced are:
* An option to control the maximum depth limit for each sync segment.
* an extension to the block hook that lets the user control the flow of
  segmented sync cycles.
* scoped block hook overrides the general block hook if both are set.

For backward compatibility, segmented sync is disabled by default. The
segmented sync is only enabled if:
* the segment depth limit is not a negative value, and
* a block hook, either general or scoped, is set.

The block hook is needed because in go-legs level, we do not have enough
information to decode a synced block and determine what its "next" link
may be. Therefore, the user of the library is required to do this and
control the flow via the segment block hook actions.

The scoped block hook overrides the general block hook, because, the
"actions" extension to the block hook modifies the state of sync.
Running both general and scoped block hook could then make conflicting
calls to the action and result in unexpected behaviour. To avoid such
edge cases, the scoped hook simply overrides the general hook if both
are set. The tests are adjusted to assert this behaviour.

Relates to: https://github.com/filecoin-project/storetheindex/issues/487