### PR TITLE
Learn HTTP publisher address from announce message

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -37,7 +37,7 @@ type httpTestEnv struct {
 func setupPublisherSubscriber(t *testing.T, subscriberOptions []legs.Option) httpTestEnv {
 	srcPrivKey, _, err := ic.GenerateECDSAKeyPair(rand.Reader)
 	if err != nil {
-		t.Fatal("Err generarting private key", err)
+		t.Fatal("Err generating private key", err)
 	}
 
 	srcHost = test.MkTestHost(libp2p.Identity(srcPrivKey))
@@ -63,8 +63,6 @@ func setupPublisherSubscriber(t *testing.T, subscriberOptions []legs.Option) htt
 	t.Cleanup(func() {
 		sub.Close()
 	})
-
-	httpPub.Address()
 
 	return httpTestEnv{
 		srcHost:    srcHost,

--- a/subscriber.go
+++ b/subscriber.go
@@ -707,6 +707,10 @@ func (s *Subscriber) Announce(ctx context.Context, nextCid cid.Cid, peerID peer.
 
 	var syncer Syncer
 	if httpAddr != nil {
+		// Store this http address so that future calls to sync will work without a
+		// peerAddr (given that it happens within the TTL)
+		s.httpPeerstore.AddAddr(peerID, httpAddr, s.addrTTL)
+
 		syncer, err = s.httpSync.NewSyncer(peerID, httpAddr, limiter)
 		if err != nil {
 			return fmt.Errorf("cannot create http sync handler: %w", err)


### PR DESCRIPTION
Populate the http peer store with the address communicated via announce
messages when the announcer is indeed a HTTP publisher.

Otherwise, subscriber falls back on libp2p host
peerstore when no other address is given during an explicit sync call
and would end up using dtsync for a HTTP publisher.

Fixes #132