### PR TITLE
Do not attempt to filter IPs on a nil multiaddr

### DIFF
--- a/mautil/mautil.go
+++ b/mautil/mautil.go
@@ -12,6 +12,9 @@ import (
 func FilterPrivateIPs(maddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
 	var pvt []int
 	for i, maddr := range maddrs {
+		if maddr == nil {
+			continue
+		}
 		ip, err := manet.ToIP(maddr)
 		if err != nil {
 			continue

--- a/mautil/mautil_test.go
+++ b/mautil/mautil_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterPrivateIPs(t *testing.T) {
@@ -44,4 +45,11 @@ func TestFilterPrivateIPs(t *testing.T) {
 	if filtered != nil {
 		t.Fatal("expected nil")
 	}
+}
+
+func TestFilterPrivateIPs_DoesNotPanicOnNilAddr(t *testing.T) {
+	original := []multiaddr.Multiaddr{nil}
+	got := FilterPrivateIPs(original)
+	// According to the function documentation, it should return the original slice.
+	require.Equal(t, original, got)
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.8"
+  "version": "v0.4.9"
 }


### PR DESCRIPTION
Check if an addr inside a multiaddr slice is nil before attempting to
filter its IP.

Bump version to bubble up the fix into storetheindex.