### PR TITLE
add local check to dtsync

### DIFF
--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -32,6 +32,7 @@ type Sync struct {
 	dtManager   dt.Manager
 	dtClose     dtCloseFunc
 	host        host.Host
+	ls          *ipld.LinkSystem
 	unsubEvents dt.Unsubscribe
 	unregHook   graphsync.UnregisterHookFunc
 
@@ -45,7 +46,7 @@ type Sync struct {
 
 // NewSyncWithDT creates a new Sync with a datatransfer.Manager provided by the
 // caller.
-func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExchange, blockHook func(peer.ID, cid.Cid)) (*Sync, error) {
+func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExchange, ls *ipld.LinkSystem, blockHook func(peer.ID, cid.Cid)) (*Sync, error) {
 	err := registerVoucher(dtManager, &Voucher{}, nil)
 	if err != nil {
 		return nil, err
@@ -54,6 +55,7 @@ func NewSyncWithDT(host host.Host, dtManager dt.Manager, gs graphsync.GraphExcha
 	s := &Sync{
 		host:         host,
 		dtManager:    dtManager,
+		ls:           ls,
 		rateLimiters: map[peer.ID]*rate.Limiter{},
 	}
 
@@ -75,6 +77,7 @@ func NewSync(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, blockH
 	s := &Sync{
 		host:         host,
 		dtManager:    dtManager,
+		ls:           &lsys,
 		dtClose:      dtClose,
 		rateLimiters: make(map[peer.ID]*rate.Limiter),
 	}
@@ -172,6 +175,7 @@ func (s *Sync) NewSyncer(peerID peer.ID, topicName string, rateLimiter *rate.Lim
 		sync:        s,
 		topicName:   topicName,
 		rateLimiter: rateLimiter,
+		ls:          s.ls,
 	}
 }
 

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -45,6 +45,8 @@ func (s *Syncer) Sync(ctx context.Context, nextCid cid.Cid, sel ipld.Node) error
 
 	// see if we already have the requested data first.
 	if s.has(ctx, nextCid, sel) {
+		inProgressSyncK := inProgressSyncKey{nextCid, s.peerID}
+		s.sync.signalSyncDone(inProgressSyncK, nil)
 		return nil
 	}
 

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -110,7 +110,7 @@ func (s *Syncer) has(ctx context.Context, nextCid cid.Cid, sel ipld.Node) bool {
 			return nil, fmt.Errorf("not available locally: %w", err)
 		}
 		// Found block read opener, so return it.
-		return r, nil		
+		return r, nil
 	}
 
 	progress := traversal.Progress{

--- a/dtsync/syncer.go
+++ b/dtsync/syncer.go
@@ -106,12 +106,11 @@ func (s *Syncer) has(ctx context.Context, nextCid cid.Cid, sel ipld.Node) bool {
 	getMissingLs.TrustedStorage = true
 	getMissingLs.StorageReadOpener = func(lc ipld.LinkContext, l ipld.Link) (io.Reader, error) {
 		r, err := s.ls.StorageReadOpener(lc, l)
-		if err == nil {
-			// Found block read opener, so return it.
-			return r, nil
+		if err != nil {
+			return nil, fmt.Errorf("not available locally: %w", err)
 		}
-
-		return nil, fmt.Errorf("not available locally")
+		// Found block read opener, so return it.
+		return r, nil		
 	}
 
 	progress := traversal.Progress{

--- a/subscriber.go
+++ b/subscriber.go
@@ -219,7 +219,7 @@ func NewSubscriber(host host.Host, ds datastore.Batching, lsys ipld.LinkSystem, 
 			cancelPubsub()
 			return nil, fmt.Errorf("datastore cannot be used with DtManager option")
 		}
-		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager, cfg.graphExchange, blockHook)
+		dtSync, err = dtsync.NewSyncWithDT(host, cfg.dtManager, cfg.graphExchange, &lsys, blockHook)
 	} else {
 		dtSync, err = dtsync.NewSync(host, ds, lsys, blockHook)
 	}

--- a/subscriber_test.go
+++ b/subscriber_test.go
@@ -366,12 +366,12 @@ func TestSyncWithHydratedDataStore(t *testing.T) {
 
 			calledTimesFirstSync := calledTimes
 
-			// Now sync again. We should call the hook because we don't have the latestSync persisted.
+			// Now sync again. We might call the hook because we don't have the latestSync persisted.
 			_, err = sub.Sync(context.Background(), pubSys.host.ID(), cid.Undef, nil, pubAddr)
 			if err != nil {
 				t.Fatal(err)
 			}
-			require.Equal(t, calledTimesFirstSync*2, calledTimes, "Expected to have called block hook twice. Once for each sync.")
+			require.GreaterOrEqual(t, calledTimes, calledTimesFirstSync, "Expected to have called block hook twice. Once for each sync.")
 		})
 	}, &quick.Config{
 		MaxCount: 5,


### PR DESCRIPTION
graphsync syncer should check if requested dags are already fully available locally before re-transferring them.