### PR TITLE
Ignore announce messages for CID seen in previous announce

### DIFF
--- a/announce_test.go
+++ b/announce_test.go
@@ -54,7 +54,7 @@ func TestAnnounceReplace(t *testing.T) {
 	// Store the whole chain in source node
 	chainLnks := test.MkChain(srcLnkS, true)
 
-	hnd, err := sub.getOrCreateHandler(srcHost.ID(), true)
+	hnd, err := sub.getOrCreateHandler(srcHost.ID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dtsync/sync.go
+++ b/dtsync/sync.go
@@ -248,7 +248,7 @@ func (s *Sync) onEvent(event dt.Event, channelState dt.ChannelState) {
 	switch channelState.Status() {
 	case dt.Completed:
 		// Tell the waiting handler that the sync has finished successfully.
-		log.Infow("datatransfer completed successfully", "cid", channelState.BaseCID(), "peer", channelState.OtherPeer())
+		log.Debugw("datatransfer completed successfully", "cid", channelState.BaseCID(), "peer", channelState.OtherPeer())
 	case dt.Cancelled:
 		// The request was canceled; inform waiting handler.
 		err = fmt.Errorf("datatransfer cancelled")

--- a/httpsync/publisher.go
+++ b/httpsync/publisher.go
@@ -123,7 +123,7 @@ func (p *publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.Error(w, "unable to load data for cid", http.StatusInternalServerError)
-		log.Errorw("Failed to load requested block", "err", err)
+		log.Errorw("Failed to load requested block", "err", err, "cid", c)
 		return
 	}
 	// marshal to json and serve.

--- a/option.go
+++ b/option.go
@@ -177,6 +177,7 @@ type DefaultLatestSyncHandler struct {
 }
 
 func (h *DefaultLatestSyncHandler) SetLatestSync(p peer.ID, c cid.Cid) {
+	log.Infow("Updating latest sync", "cid", c, "peer", p)
 	h.m.Store(p, c)
 }
 

--- a/string_lru.go
+++ b/string_lru.go
@@ -1,0 +1,45 @@
+package legs
+
+import "container/list"
+
+type stringLRU struct {
+	cache map[string]*list.Element
+	ll    *list.List
+	max   int
+}
+
+func newStringLRU(maxEntries int) *stringLRU {
+	return &stringLRU{
+		cache: make(map[string]*list.Element, maxEntries),
+		ll:    list.New(),
+		max:   maxEntries,
+	}
+}
+
+func (l *stringLRU) len() int {
+	return l.ll.Len()
+}
+
+func (l *stringLRU) remove(s string) bool {
+	if elem, hit := l.cache[s]; hit {
+		l.ll.Remove(elem)
+		delete(l.cache, s)
+		return true
+	}
+	return false
+}
+
+func (l *stringLRU) update(s string) bool {
+	if elem, hit := l.cache[s]; hit {
+		l.ll.MoveToFront(elem)
+		return true
+	}
+
+	if l.ll.Len() == l.max {
+		oldest := l.ll.Back()
+		l.ll.Remove(oldest)
+		delete(l.cache, oldest.Value.(string))
+	}
+	l.cache[s] = l.ll.PushFront(s)
+	return false
+}

--- a/string_lru_test.go
+++ b/string_lru_test.go
@@ -1,0 +1,35 @@
+package legs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdate(t *testing.T) {
+	lru := newStringLRU(3)
+	require.Zero(t, lru.len())
+
+	hit := lru.update("hello")
+	require.False(t, hit)
+	require.Equal(t, 1, lru.len())
+
+	hit = lru.update("hello")
+	require.True(t, hit)
+	require.Equal(t, 1, lru.len())
+
+	lru.update("foo")
+	lru.update("bar")
+	require.Equal(t, 3, lru.len())
+	lru.update("baz")
+	require.Equal(t, 3, lru.len())
+
+	hit = lru.update("hello")
+	require.False(t, hit)
+
+	hit = lru.update("bar")
+	require.True(t, hit)
+
+	require.True(t, lru.remove("bar"))
+	require.False(t, lru.remove("bar"))
+}


### PR DESCRIPTION
When multiple indexers receive the same re-published direct announce messages from multiple peers, or receive the same announce messages both directly and over gossib-sub, these duplicate messages cause unnecessary processing.

This PR uses a small LRU cache to discard announce messages with recently seen CIDs.

Also, minor log message improvements and less logging at info level